### PR TITLE
fix: nextjs config 파일 빌드 경고

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,18 +1,24 @@
 import type { NextConfig } from 'next';
 
+
+
+
+
 const nextConfig: NextConfig = {
     reactStrictMode: true, // 개발 중 잠재적 문제를 조기에 발견하기 위한 설정
-    swcMinify: true, // Rust 기반 컴파일러로 빌드 속도 향상
+    // Next.js 에서 이제 디폴트로 관리되어 불필요한 설정이라 주석 처리 하였습니다.
+    // swcMinify: true, // Rust 기반 컴파일러로 빌드 속도 향상
     compress: true, // 응답 압축으로 성능 향상
     poweredByHeader: false, // 보안을 위해 X-Powered-By 헤더 제거
     images: {
-        domains: [], // 외부 이미지 도메인 허용 목록
+        remotePatterns: [], // 외부 이미지 도메인 허용 목록 -> domains -> remotePatterns 로 수정 하였습니다.
         formats: ['image/webp', 'image/avif'], // 최신 이미지 포맷 지원
     },
-    i18n: {
-        locales: ['ko', 'en'],
-        defaultLocale: 'ko',
-    },
+    // 미들웨어에서 이미 처리하고 있고, 레거시 설정이라 주석처리 하였습니다.
+    // i18n: {
+    //     locales: ['ko', 'en'],
+    //     defaultLocale: 'ko',
+    // },
 };
 
 export default nextConfig;


### PR DESCRIPTION
- swcMinify 옵션 제거 (기본값으로 사용됨)
- i18n 설정 제거 (App Router에서 미들웨어 활용 방식으로 변경되었으며 이미 적절히 처리중)
- images.domains 대신 remotePatterns 사용

Fixes #22