### PR TITLE
bug/responsive layout

### DIFF
--- a/src/components/common/RecruitPost.tsx
+++ b/src/components/common/RecruitPost.tsx
@@ -11,7 +11,7 @@ export default function RecruitPost() {
     ];
 
     return (
-        <article className="flex flex-col w-[580px] gap-2.5 px-[34px] py-[30px] bg-[#f5f6f7] rounded-xl">
+        <article className="flex flex-col gap-2.5 px-[34px] py-[30px] bg-[#f5f6f7] rounded-xl">
             {/* 헤더 섹션 */}
             <header className="flex flex-col w-full">
                 <div className="flex items-center gap-2 w-full mb-2">
@@ -73,7 +73,7 @@ export default function RecruitPost() {
             <hr className="w-full h-px border-0 bg-gray-200 mb-3.5" />
 
             {/* 유저 프로필 */}
-            <section className="flex items-center justify-between w-full">
+            <section className="flex flex-col md:flex-row items-start md:items-center justify-between w-full gap-4 md:gap-2">
                 {/* 아이콘 */}
                 <div className="flex items-center gap-3">
                     <div className="w-[50px] h-[50px] rounded-full overflow-hidden">
@@ -108,15 +108,15 @@ export default function RecruitPost() {
                 </div>
 
                 {/* 상호작용 버튼 */}
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 w-full md:w-auto">
                     <Button
                         variant="outline"
-                        className="flex items-center gap-1.5 px-[30px] py-2 bg-white rounded-lg"
+                        className="flex items-center gap-1.5 px-[30px] py-2 bg-white rounded-lg flex-1 md:flex-none"
                     >
                         <Heart />
                         <span className="font-semibold">찜하기</span>
                     </Button>
-                    <Button className="flex items-center gap-2.5 px-[30px] py-2 bg-sky-blue rounded-lg">
+                    <Button className="flex items-center gap-2.5 px-[30px] py-2 bg-sky-blue rounded-lg flex-1">
                         <span className="font-semibold text-white text-sm leading-[21px]">
                             동행하기
                         </span>

--- a/src/components/home/FilterSelector.tsx
+++ b/src/components/home/FilterSelector.tsx
@@ -41,7 +41,7 @@ export default function FilterSelector() {
                     <Button
                         variant={'outline'}
                         className={cn(
-                            'gap-9 pl-7 pr-[18px] h-auto w-full min-w-[200px] flex-1',
+                            'gap-9 pl-7 pr-[18px] h-auto w-[273px] min-w-[200px]',
                             !date && 'text-[#999999]',
                         )}
                     >
@@ -94,7 +94,7 @@ export default function FilterSelector() {
 
             {/* 동행 테마 */}
             <Select>
-                <SelectTrigger className="gap-9 pl-7 pr-[18px] py-4 h-auto min-w-[150px] flex-1">
+                <SelectTrigger className="gap-9 pl-7 pr-[18px] py-4 h-auto min-w-[150px]">
                     <div className="flex gap-5">
                         <Image
                             src="/icon/home/openedBookIcon.svg"
@@ -112,7 +112,7 @@ export default function FilterSelector() {
 
             {/* 동행 인원 */}
             <Select>
-                <SelectTrigger className="gap-6 pl-7 pr-[18px] py-4 h-auto min-w-[150px] flex-1">
+                <SelectTrigger className="gap-6 pl-7 pr-[18px] py-4 h-auto min-w-[150px]">
                     <div className="flex gap-5">
                         <Image
                             src="/icon/home/groupIcon.svg"
@@ -130,7 +130,7 @@ export default function FilterSelector() {
 
             {/* 선호 정보 */}
             <Select>
-                <SelectTrigger className="gap-6 pl-7 pr-[18px] py-4 h-auto min-w-[150px] flex-1">
+                <SelectTrigger className="gap-6 pl-7 pr-[18px] py-4 h-auto min-w-[150px]">
                     <div className="flex gap-5">
                         <Image
                             src="/icon/home/smileIcon.svg"
@@ -149,7 +149,7 @@ export default function FilterSelector() {
             {/* 검색 버튼 */}
             <Button
                 variant="default"
-                className="gap-9 px-8 py-4 h-auto font-semibold text-base flex-1 min-w-[100px]"
+                className="gap-9 px-8 py-4 h-auto font-semibold text-base min-w-[100px]"
             >
                 검색
             </Button>

--- a/src/components/home/FilterSelector.tsx
+++ b/src/components/home/FilterSelector.tsx
@@ -20,9 +20,9 @@ export default function FilterSelector() {
     const [date, setDate] = useState<DateRange | undefined>(undefined);
 
     return (
-        <div className="flex w-full gap-2">
+        <div className="flex flex-wrap w-full gap-2">
             {/* 여행지 설정 */}
-            <div className="inline-flex gap-9 px-7 py-4 rounded-lg border border-solid border-[#e9e9e9]">
+            <div className="inline-flex gap-9 px-7 py-4 rounded-lg border border-solid border-[#e9e9e9] flex-1 min-w-[200px]">
                 <Image
                     src="/icon/home/pinIcon.svg"
                     alt="위치 아이콘"
@@ -41,7 +41,7 @@ export default function FilterSelector() {
                     <Button
                         variant={'outline'}
                         className={cn(
-                            'gap-9 pl-7 pr-[18px] h-auto min-w-[273px]',
+                            'gap-9 pl-7 pr-[18px] h-auto w-full min-w-[200px] flex-1',
                             !date && 'text-[#999999]',
                         )}
                     >
@@ -94,7 +94,7 @@ export default function FilterSelector() {
 
             {/* 동행 테마 */}
             <Select>
-                <SelectTrigger className="gap-9 pl-7 pr-[18px] py-4  h-auto">
+                <SelectTrigger className="gap-9 pl-7 pr-[18px] py-4 h-auto min-w-[150px] flex-1">
                     <div className="flex gap-5">
                         <Image
                             src="/icon/home/openedBookIcon.svg"
@@ -112,7 +112,7 @@ export default function FilterSelector() {
 
             {/* 동행 인원 */}
             <Select>
-                <SelectTrigger className="gap-6 pl-7 pr-[18px] py-4 h-auto">
+                <SelectTrigger className="gap-6 pl-7 pr-[18px] py-4 h-auto min-w-[150px] flex-1">
                     <div className="flex gap-5">
                         <Image
                             src="/icon/home/groupIcon.svg"
@@ -130,7 +130,7 @@ export default function FilterSelector() {
 
             {/* 선호 정보 */}
             <Select>
-                <SelectTrigger className="gap-6 pl-7 pr-[18px] py-4 h-auto">
+                <SelectTrigger className="gap-6 pl-7 pr-[18px] py-4 h-auto min-w-[150px] flex-1">
                     <div className="flex gap-5">
                         <Image
                             src="/icon/home/smileIcon.svg"
@@ -149,7 +149,7 @@ export default function FilterSelector() {
             {/* 검색 버튼 */}
             <Button
                 variant="default"
-                className="gap-9 px-8 py-4 h-auto font-semibold text-base"
+                className="gap-9 px-8 py-4 h-auto font-semibold text-base flex-1 min-w-[100px]"
             >
                 검색
             </Button>

--- a/src/components/home/InfiniteScroll.tsx
+++ b/src/components/home/InfiniteScroll.tsx
@@ -39,23 +39,16 @@ export default function InfiniteScroll() {
     }, [isInView, fetchNextPage, hasNextPage, isFetchingNextPage]);
 
     return (
-        <div
-            className="mt-6 grid gap-y-10"
-            style={{ gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)' }}
-        >
+        <div className="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6 max-w-[1200px] px-4">
             {data?.pages.map((page) =>
                 page.map((post: Post) => (
-                    <div
-                        key={post.id}
-                        className="gap-10 place-self-start even:place-self-end"
-                    >
+                    <div key={post.id}>
                         <RecruitPost />
                     </div>
                 )),
             )}
             {isFetchingNextPage && (
-                <div className="col-span-2 flex justify-center items-center py-4">
-                    {/* 로딩 중 ui */}
+                <div className="col-span-full flex justify-center items-center py-4">
                     <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-black"></div>
                 </div>
             )}

--- a/src/components/home/InfiniteScroll.tsx
+++ b/src/components/home/InfiniteScroll.tsx
@@ -39,7 +39,7 @@ export default function InfiniteScroll() {
     }, [isInView, fetchNextPage, hasNextPage, isFetchingNextPage]);
 
     return (
-        <div className="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6 max-w-[1200px] px-4">
+        <div className="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6 max-w-[1200px]">
             {data?.pages.map((page) =>
                 page.map((post: Post) => (
                     <div key={post.id}>

--- a/src/components/home/TrendingCarousel.tsx
+++ b/src/components/home/TrendingCarousel.tsx
@@ -1,6 +1,12 @@
-import {CardContent} from '@/components/ui/card';
-import {Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious,} from '@/components/ui/carousel';
-import {cn} from '@/lib';
+import { CardContent } from '@/components/ui/card';
+import {
+    Carousel,
+    CarouselContent,
+    CarouselItem,
+    CarouselNext,
+    CarouselPrevious,
+} from '@/components/ui/carousel';
+import { cn } from '@/lib';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -10,14 +16,15 @@ interface TrendingCarouselProps {
     className?: string;
 }
 
-export function TrendingCarousel({className}: TrendingCarouselProps) {
+export function TrendingCarousel({ className }: TrendingCarouselProps) {
     return (
         <div className={cn('w-full relative overflow-hidden', className)}>
-            <Carousel className="w-full " opts={{
-                align: "start",
-            }}
+            <Carousel
+                className="w-full "
+                opts={{
+                    align: 'start',
+                }}
             >
-
                 <section className={`flex justify-between`}>
                     <div className={`flex gap-2 mb-5 align-center`}>
                         <Image
@@ -49,8 +56,7 @@ export function TrendingCarousel({className}: TrendingCarouselProps) {
                             key={index}
                             className="basis-auto min-w-[400px] "
                         >
-                            <CardContent
-                                className="relative overflow-hidden w-[400px] h-[248px] flex items-center justify-center rounded-xl p-0 cursor-pointer">
+                            <CardContent className="relative overflow-hidden w-[400px] h-[248px] flex items-center justify-center rounded-xl p-0 cursor-pointer">
                                 <Link
                                     href={`/buddy/${trend.id}`}
                                     className="w-full h-full relative "
@@ -63,15 +69,13 @@ export function TrendingCarousel({className}: TrendingCarouselProps) {
                                         priority
                                     />
                                     {/* 이미지와 더 자연스럽게 어울리는 그라데이션 오버레이 */}
-                                    <div
-                                        className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent"/>
+                                    <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
                                 </Link>
 
                                 {/* 텍스트 정보 - 더 나은 위치 지정을 위해 그라데이션 div 외부로 이동 */}
                                 <div className="absolute bottom-0 left-0 w-full p-4 text-white">
                                     {/* 프로필 정보 */}
                                     <div className="flex items-center w-full">
-
                                         <Link
                                             href={`/profile/${trend.userId}`}
                                             className="flex items-center gap-2 mb-2 w-auto transition-colors hover:text-sky-blue"
@@ -84,16 +88,15 @@ export function TrendingCarousel({className}: TrendingCarouselProps) {
                                                 className="rounded-full"
                                             />
                                             <span className="text-sm font-semibold">
-                                            {trend.userName}
-                                        </span>
+                                                {trend.userName}
+                                            </span>
                                             <span className="text-sm">
-                                            {trend.age} · {trend.gender}
-                                        </span>
+                                                {trend.age} · {trend.gender}
+                                            </span>
                                         </Link>
                                         <div className="flex-grow"></div>
-
                                     </div>
-                                    <div className="flex justify-between px-4">
+                                    <div className="flex justify-between">
                                         {/* 제목 */}
                                         <p className="text-base font-semibold">
                                             {trend.title}


### PR DESCRIPTION
## 작업 내용
1. 필터영역, 무한스크롤 영역 반응형 대응 최소로 추가
→ https://github.com/Wego-A-Journey-Together/Wego-FE/issues/36 관련 이슈는 좌측 링크에 좀 더 자세히 서술 했습니다.
3. 캐러셀 하단 제목 날짜에 `px-4`로 인해 프로필 아이콘과 align 안맞는 부분 수정
→ 피그마에서는 아이콘 이미지와 제목의 시작점이 정렬돼있어 반영했습니다.
<img width="400" alt="스크린샷 2025-03-18 오후 6 38 34" src="https://github.com/user-attachments/assets/431ce0e9-7385-4418-97c3-1689f8464df5" />




## 수정 후 이미지
*반응형 디자인 구체적으로 정해지면 추가 수정하겠습니다.
<img width="400" alt="스크린샷 2025-03-18 오후 7 04 21" src="https://github.com/user-attachments/assets/f925d933-5c0a-4dd9-b30b-6978e4b20696" />
