### PR TITLE
style: 메인 페이지 Carousel 반응형 스타일링

### DIFF
--- a/src/components/home/TrendingCarousel.tsx
+++ b/src/components/home/TrendingCarousel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CardContent } from '@/components/ui/card';
 import {
     Carousel,
@@ -9,6 +11,7 @@ import {
 import { cn } from '@/lib';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 import trendingPost from '../../../public/data/trending';
 
@@ -17,34 +20,52 @@ interface TrendingCarouselProps {
 }
 
 export function TrendingCarousel({ className }: TrendingCarouselProps) {
+    const [align, setAlign] = useState<'start' | 'center'>('start');
+
+    useEffect(() => {
+        const handleResize = () => {
+            if (window.innerWidth < 768) {
+                setAlign('center');
+            } else {
+                setAlign('start');
+            }
+        };
+
+        // 초기 실행 및 이벤트 등록
+        handleResize();
+        window.addEventListener('resize', handleResize);
+
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
     return (
-        <div className={cn('w-full relative overflow-hidden', className)}>
+        <div className={cn('relative w-full overflow-hidden', className)}>
             <Carousel
-                className="w-full "
+                className="w-full"
                 opts={{
-                    align: 'start',
+                    align,
+                    loop: true,
                 }}
             >
                 <section className={`flex justify-between`}>
-                    <div className={`flex gap-2 mb-5 align-center`}>
+                    <div className={`align-center mb-5 flex gap-2`}>
                         <Image
                             src={'/icon/trending.png'}
                             alt={'Hot'}
                             width={26}
                             height={26}
                         />
-                        <h2 className={`flex font-semibold text-xl`}>
+                        <h2 className={`flex text-xl font-semibold`}>
                             이번 주 Hot한 동행
                         </h2>
                     </div>
                     {/* 버튼 컨테이너 - absolute 포지셔닝을 제거하여 flex 내에 유지 */}
-                    <div className="flex justify-end mt-5">
+                    <div className="mt-5 flex justify-end">
                         <CarouselPrevious
-                            className="relative left-0 right-0 top-0 transform-none m-0 h-8 bg-transparent border border-gray-200 rounded-l-md rounded-r-none border-r-0 shadow-none hover:bg-gray-50"
+                            className="relative top-0 right-0 left-0 m-0 h-8 transform-none rounded-l-md rounded-r-none border border-r-0 border-gray-200 bg-transparent shadow-none hover:bg-gray-50"
                             variant="ghost"
                         />
                         <CarouselNext
-                            className="relative left-0 right-0 top-0 transform-none m-0 h-8 bg-transparent border border-gray-200 rounded-r-md rounded-l-none shadow-none hover:bg-gray-50"
+                            className="relative top-0 right-0 left-0 m-0 h-8 transform-none rounded-l-none rounded-r-md border border-gray-200 bg-transparent shadow-none hover:bg-gray-50"
                             variant="ghost"
                         />
                     </div>
@@ -54,12 +75,12 @@ export function TrendingCarousel({ className }: TrendingCarouselProps) {
                     {trendingPost.map((trend, index) => (
                         <CarouselItem
                             key={index}
-                            className="basis-auto min-w-[400px] "
+                            className="min-w-[400px] basis-auto"
                         >
-                            <CardContent className="relative overflow-hidden w-[400px] h-[248px] flex items-center justify-center rounded-xl p-0 cursor-pointer">
+                            <CardContent className="relative flex h-[248px] w-[400px] cursor-pointer items-center justify-center overflow-hidden rounded-xl p-0">
                                 <Link
                                     href={`/buddy/${trend.id}`}
-                                    className="w-full h-full relative "
+                                    className="relative h-full w-full"
                                 >
                                     <Image
                                         src={trend.imageSrc}
@@ -75,10 +96,10 @@ export function TrendingCarousel({ className }: TrendingCarouselProps) {
                                 {/* 텍스트 정보 - 더 나은 위치 지정을 위해 그라데이션 div 외부로 이동 */}
                                 <div className="absolute bottom-0 left-0 w-full p-4 text-white">
                                     {/* 프로필 정보 */}
-                                    <div className="flex items-center w-full">
+                                    <div className="flex w-full items-center">
                                         <Link
                                             href={`/profile/${trend.userId}`}
-                                            className="flex items-center gap-2 mb-2 w-auto transition-colors hover:text-sky-blue"
+                                            className="hover:text-sky-blue mb-2 flex w-auto items-center gap-2 transition-colors"
                                         >
                                             <Image
                                                 src={trend.profileImage}
@@ -119,7 +140,7 @@ export function TrendingCarousel({ className }: TrendingCarouselProps) {
                                 </div>
                             </CardContent>
                         </CarouselItem>
-                    ))}
+                    ))}{' '}
                 </CarouselContent>
             </Carousel>
         </div>


### PR DESCRIPTION
### 문제 상황
![image](https://github.com/user-attachments/assets/74aa06f0-1148-4cd3-9527-b04fb41e31da)

- 시안과 맞추기 위해 opt 에서 align start 설정이 필요합니다..
- 그런데 모바일 에서 align start 적용시 화면 좌측으로 이미지가 배치되는 문제

https://github.com/user-attachments/assets/d3a965d6-3a17-4079-b792-5ad8df88bb71


### 해결 방법
- useEffect 를 사용하여 화면 사이즈별로 opt 수정 
- 모바일: center, 이외 start

(#13 #30 )