### PR TITLE
design: 찜 버튼 디자인 변경 반영, 상세페이지 낙관적 업데이트 반영

### DIFF
--- a/src/app/[lang]/detail/[id]/page.tsx
+++ b/src/app/[lang]/detail/[id]/page.tsx
@@ -1,7 +1,7 @@
+import OptimisticUpdateLikes from '@/components/Btn/OptimisticUpdateLikes';
 import RecruitFooter from '@/components/detail/RecruitFooter';
 import TabSection from '@/components/detail/TabSection';
 import UserProfile from '@/components/detail/UserProfile';
-import { Bookmark } from 'lucide-react';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
 
@@ -45,8 +45,10 @@ export default async function DetailPage({ params }: TestPageProps) {
                         <span>댓글 {post.commentCount}</span>
                     </div>
                 </div>
-                {/*todo: isBookMarked? 조건부 fill */}
-                <Bookmark fill={`black`} className={`my-auto`} />
+                <OptimisticUpdateLikes
+                    className={`my-auto px-0`}
+                    id={post.id}
+                />
             </section>
             {/*주최자정보섹션*/}
             <section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,7 +12,7 @@
 
 :root {
     /*피그마 시안 컬러 적용*/
-    --background-light: #ffffff;
+    --background-light: #f5f5f5;
     --sky-blue: #0ac7e4;
     /*--------------*/
     --background: oklch(1 0 0);
@@ -154,6 +154,7 @@
     .font-orienta {
         font-family: var(--font-orienta, Orienta), sans-serif;
     }
+
     .font-pretendard {
         font-family: var(--font-pretendard), sans-serif;
     }

--- a/src/components/Btn/OptimisticUpdateLikes.tsx
+++ b/src/components/Btn/OptimisticUpdateLikes.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
 import { cn } from '@/lib';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Heart } from 'lucide-react';
+import { Bookmark } from 'lucide-react';
 import { useState } from 'react';
 
 interface OptimisticUpdateLikesProps {
     id: number;
+    className?: string;
 }
 
 interface ItemData {
@@ -16,6 +16,7 @@ interface ItemData {
 
 export default function OptimisticUpdateLikes({
     id,
+    className,
 }: OptimisticUpdateLikesProps) {
     const [isLike, setIsLike] = useState<boolean>(false);
     const queryClient = useQueryClient();
@@ -115,18 +116,19 @@ export default function OptimisticUpdateLikes({
     };
 
     return (
-        <Button
-            variant="outline"
-            className="flex flex-1 items-center gap-1.5 rounded-lg bg-white px-[30px] py-2 md:flex-none"
+        <div
+            className={cn(
+                'flex flex-1 items-center gap-1.5 rounded-lg bg-white px-[30px] py-2 md:flex-none',
+                className,
+            )}
             onClick={handleClick}
         >
-            <Heart
+            <Bookmark
                 className={cn(
-                    'transition-colors',
-                    isLike && 'fill-rose-700 stroke-rose-500',
+                    'stroke-[#666666] stroke-1 transition-colors',
+                    isLike && 'fill-neutral-500',
                 )}
             />
-            <span className="font-semibold">찜하기</span>
-        </Button>
+        </div>
     );
 }

--- a/src/components/common/RecruitPost.tsx
+++ b/src/components/common/RecruitPost.tsx
@@ -1,5 +1,4 @@
 import OptimisticUpdateLikes from '@/components/Btn/OptimisticUpdateLikes';
-import { Button } from '@/components/ui/button';
 import Image from 'next/image';
 
 //todo : 현재는 낙관적 업데이트를 위한 단순한 id 만 정의 (데이터 바인딩 x )
@@ -115,12 +114,7 @@ export default function RecruitPost({ id }: RecruitPostProps) {
                 {/* 상호작용 버튼 */}
                 <div className="flex w-full items-center gap-2 md:w-auto">
                     {/*낙관적 업데이트 찜 버튼*/}
-                    <OptimisticUpdateLikes id={id} />
-                    <Button className="bg-sky-blue flex flex-1 items-center gap-2.5 rounded-lg px-[30px] py-2">
-                        <span className="text-sm leading-[21px] font-semibold text-white">
-                            동행하기
-                        </span>
-                    </Button>
+                    <OptimisticUpdateLikes id={id} className={`px-0`} />
                 </div>
             </section>
         </article>


### PR DESCRIPTION
### 작업내용
- 찜 버튼 하트에서 북마크로 변경
- 상세 페이지 낙관적 업데이트 컴포넌트로 변경
- 홈페이지 동행하기 버튼 제거
- 배경색 figma와 동일하게 설정