### PR TITLE
design: 상세페이지 내에 채팅 ui 구현

### DIFF
--- a/src/app/[lang]/detail/[id]/page.tsx
+++ b/src/app/[lang]/detail/[id]/page.tsx
@@ -58,7 +58,7 @@ export default async function DetailPage({ params }: TestPageProps) {
             {/*푸터 섹션 (참여하기,문의채팅)*/}
             {/* 푸터 마진 */}
             <div className={`h-20`} />
-            <RecruitFooter title={post.title} />
+            <RecruitFooter post={post} />
         </div>
     );
 }

--- a/src/components/common/ChatList.tsx
+++ b/src/components/common/ChatList.tsx
@@ -1,0 +1,78 @@
+// 임시 TODO: 실제 채팅 데이터 불러오기
+type Message = {
+    messageId: number;
+    text: string;
+    messageFrom: 'user' | 'writer';
+    timestamp: string;
+};
+
+// 테스트용 채팅 데이터
+const testMessages: Message[] = [
+    {
+        messageId: 1,
+        text: '안녕하세요! 이 여행에 관심이 있어요.',
+        messageFrom: 'user',
+        timestamp: '14:30',
+    },
+    {
+        messageId: 2,
+        text: '안녕하세요! 관심 가져주셔서 감사합니다. 어떤 점이 궁금하신가요?',
+        messageFrom: 'writer',
+        timestamp: '14:32',
+    },
+    {
+        messageId: 3,
+        text: '여행 일정이 어떻게 되나요? 그리고 참가비에는 어떤 것들이 포함되어 있나요?',
+        messageFrom: 'user',
+        timestamp: '14:35',
+    },
+    {
+        messageId: 4,
+        text: '일정은 게시글에 적힌 대로 3박 4일이고, 참가비에는 숙박비와 일부 식사비가 포함되어 있습니다. 교통비는 별도입니다.',
+        messageFrom: 'writer',
+        timestamp: '14:40',
+    },
+];
+
+export default function ChatList() {
+    return (
+        <div className="flex flex-col">
+            {testMessages.map((chatData) => (
+                <div
+                    key={chatData.messageId}
+                    className={`mb-4 flex ${
+                        chatData.messageFrom === 'user'
+                            ? 'justify-end pr-5'
+                            : 'justify-start pl-5'
+                    }`}
+                >
+                    {chatData.messageFrom === 'writer' && (
+                        <div className="mr-2.5 h-[30px] w-[30px] rounded-full bg-gray-200"></div>
+                    )}
+                    <div
+                        className={`flex items-end gap-1.5 ${
+                            chatData.messageFrom === 'user'
+                                ? 'flex-row-reverse'
+                                : 'flex-row'
+                        }`}
+                    >
+                        <div
+                            className={`inline-flex max-w-xs items-center justify-center rounded-2xl p-2.5 ${
+                                chatData.messageFrom === 'user'
+                                    ? 'bg-[#0ac7e414]'
+                                    : 'bg-[#f5f6f7]'
+                            }`}
+                        >
+                            <div className="text-base leading-[20.8px] font-medium text-black">
+                                {chatData.text}
+                            </div>
+                        </div>
+                        <div className="text-xs leading-[21px] font-normal whitespace-nowrap text-[#333333]">
+                            {chatData.timestamp}
+                        </div>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/common/ChatNotice.tsx
+++ b/src/components/common/ChatNotice.tsx
@@ -1,0 +1,26 @@
+export default function ChatNotice() {
+    return (
+        <div className="flex h-full items-center justify-center">
+            <div className="max-w-[368px] rounded-xl bg-[#f9f9f9] p-5">
+                <h3 className="mb-[30px] text-center text-lg font-semibold text-[#333333]">
+                    🎁 동행 찾기를 위한 TIP 🎁
+                </h3>
+                <h4 className="mb-5 text-center text-base font-semibold text-[#333333]">
+                    여행 스타일을 파악할 수 있게 자기소개를 나눠보세요
+                </h4>
+                {/* 메세지 없는 경우에만 출력 */}
+                <p className="text-center text-sm leading-[18.2px] text-[#333333]">
+                    ex) 안녕하세요! 20대 중반 직장인입니다.
+                    <br />
+                    뭐든지 잘 먹어서 저랑 함께하지면
+                    <br />
+                    여러 메뉴를 드셔보실 수 있으실 겁니다.
+                    <br />
+                    친화력도 엄청 좋은 ENFP이니 걱정말고
+                    <br />
+                    여행을 같이 즐겨봐요!
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/src/components/common/userChat.tsx
+++ b/src/components/common/userChat.tsx
@@ -5,6 +5,9 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Calendar, MoreHorizontal, Star, X } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 
+import ChatList from './ChatList';
+import ChatNotice from './ChatNotice';
+
 interface UserChatProps extends PostContentProps {
     onClose?: () => void;
     onParticipate?: () => void;
@@ -121,29 +124,8 @@ export default function UserChat({
 
                     {/* 채팅 말풍선 섹션 */}
                     <section className="flex-1 overflow-y-auto p-4">
-                        <div className="flex h-full items-center justify-center">
-                            <div className="max-w-[368px] rounded-xl bg-[#f9f9f9] p-5">
-                                <h3 className="mb-[30px] text-center text-lg font-semibold text-[#333333]">
-                                    🎁 동행 찾기를 위한 TIP 🎁
-                                </h3>
-                                <h4 className="mb-5 text-center text-base font-semibold text-[#333333]">
-                                    여행 스타일을 파악할 수 있게 자기소개를
-                                    나눠보세요
-                                </h4>
-                                {/* 메세지 없는 경우에만 출력 */}
-                                <p className="text-center text-sm leading-[18.2px] text-[#333333]">
-                                    ex) 안녕하세요! 20대 중반 직장인입니다.
-                                    <br />
-                                    뭐든지 잘 먹어서 저랑 함께하지면
-                                    <br />
-                                    여러 메뉴를 드셔보실 수 있으실 겁니다.
-                                    <br />
-                                    친화력도 엄청 좋은 ENFP이니 걱정말고
-                                    <br />
-                                    여행을 같이 즐겨봐요!
-                                </p>
-                            </div>
-                        </div>
+                        {/* TODO 조건 부분에 메세지가 있는지 없는지 반환 필요 */}
+                        {true ? <ChatList /> : <ChatNotice />}
                     </section>
 
                     {/* 메세지 입력 영역 */}

--- a/src/components/common/userChat.tsx
+++ b/src/components/common/userChat.tsx
@@ -1,0 +1,171 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { PostContentProps } from '@/types/PostContent';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Calendar, MoreHorizontal, Star, X } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+
+interface UserChatProps extends PostContentProps {
+    onClose?: () => void;
+    onParticipate?: () => void;
+}
+
+export default function UserChat({
+    post,
+    onClose,
+    onParticipate,
+}: UserChatProps) {
+    const [isVisible, setIsVisible] = useState(true);
+
+    const handleClose = () => {
+        setIsVisible(false);
+    };
+
+    // 문의 채팅 슬라이드 애니메이션
+    useEffect(() => {
+        if (!isVisible && onClose) {
+            const timer = setTimeout(() => {
+                onClose();
+            }, 300);
+            return () => clearTimeout(timer);
+        }
+    }, [isVisible, onClose]);
+
+    const slideIn = {
+        hidden: { x: '100%' },
+        visible: {
+            x: 0,
+            transition: {
+                type: 'spring',
+                stiffness: 300,
+                damping: 30,
+            },
+        },
+        exit: {
+            x: '100%',
+            transition: {
+                type: 'spring',
+                stiffness: 300,
+                damping: 30,
+                duration: 0.3,
+            },
+        },
+    };
+
+    return (
+        <AnimatePresence>
+            {isVisible && (
+                <motion.div
+                    className="fixed inset-y-0 right-0 flex w-[580px] flex-col bg-white shadow-lg"
+                    initial="hidden"
+                    animate="visible"
+                    exit="exit"
+                    variants={slideIn}
+                >
+                    {/* 채팅창 헤더 */}
+                    <header className="flex h-[72px] w-full items-center justify-between px-5 py-2.5">
+                        <button
+                            className="flex h-6 w-6 items-center justify-center"
+                            onClick={handleClose}
+                            aria-label="창 닫기"
+                        >
+                            <X className="h-4 w-4" />
+                        </button>
+                        <div className="inline-flex items-center gap-1">
+                            {/* 유저 아이디 */}
+                            <span className="text-[15px] font-semibold text-black">
+                                {post.userName}
+                            </span>
+
+                            <div className="inline-flex items-center gap-1 rounded-[50px] bg-[#ffd8001a] px-2 py-1 text-[#614e03]">
+                                <Star className="h-4 w-4 fill-[#FFD800] text-[#FFD800]" />
+
+                                {/* 유저 평점 */}
+                                <span className="text-xs font-medium">
+                                    {post.rating}
+                                </span>
+                            </div>
+                        </div>
+                        <button
+                            className="flex h-6 w-6 items-center justify-center"
+                            aria-label="MoreHorizontal options"
+                        >
+                            <MoreHorizontal className="h-5 w-5 text-[#333333]" />
+                        </button>
+                    </header>
+
+                    {/* 게시글 제목, 상태, 참여하기 버튼 섹션 */}
+                    <section className="flex w-full flex-col gap-2.5 border-b px-5 py-4">
+                        <div className="flex w-full items-center justify-between">
+                            <div className="flex w-[365px] flex-col gap-[3px]">
+                                <h2 className="text-base font-semibold">
+                                    {post.title}
+                                </h2>
+                                <div className="flex items-center gap-[3px]">
+                                    <Calendar className="h-4 w-4 text-[#666666]" />
+                                    <h3 className="text-sm font-normal whitespace-nowrap text-[#666666]">
+                                        {/* TODO 날짜 계산해서 며칠 동안 모집하는지 표기 필요 */}
+                                        {`${post.startDate} - ${post.endDate}`}
+                                    </h3>
+                                </div>
+                            </div>
+
+                            <Button
+                                className="px-[30px] py-2"
+                                onClick={onParticipate}
+                            >
+                                참여하기
+                            </Button>
+                        </div>
+                    </section>
+
+                    {/* 채팅 말풍선 섹션 */}
+                    <section className="flex-1 overflow-y-auto p-4">
+                        <div className="flex h-full items-center justify-center">
+                            <div className="max-w-[368px] rounded-xl bg-[#f9f9f9] p-5">
+                                <h3 className="mb-[30px] text-center text-lg font-semibold text-[#333333]">
+                                    🎁 동행 찾기를 위한 TIP 🎁
+                                </h3>
+                                <h4 className="mb-5 text-center text-base font-semibold text-[#333333]">
+                                    여행 스타일을 파악할 수 있게 자기소개를
+                                    나눠보세요
+                                </h4>
+                                {/* 메세지 없는 경우에만 출력 */}
+                                <p className="text-center text-sm leading-[18.2px] text-[#333333]">
+                                    ex) 안녕하세요! 20대 중반 직장인입니다.
+                                    <br />
+                                    뭐든지 잘 먹어서 저랑 함께하지면
+                                    <br />
+                                    여러 메뉴를 드셔보실 수 있으실 겁니다.
+                                    <br />
+                                    친화력도 엄청 좋은 ENFP이니 걱정말고
+                                    <br />
+                                    여행을 같이 즐겨봐요!
+                                </p>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* 메세지 입력 영역 */}
+                    <section className="flex w-[580px] flex-col items-center justify-center gap-2.5 bg-white px-2.5 py-5">
+                        <div className="w-[540px] rounded-xl border-solid bg-[#f9f9f9]">
+                            <div className="p-5">
+                                <div className="flex flex-col gap-10">
+                                    <Input
+                                        placeholder="메세지를 입력하세요"
+                                        className="border-none bg-transparent text-base leading-[20.8px] font-normal text-[#999999] shadow-none focus-visible:ring-0"
+                                    />
+                                    <div className="flex w-full items-center justify-end gap-2">
+                                        <Button className="px-5 py-2">
+                                            전송
+                                        </Button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+}

--- a/src/components/detail/RecruitFooter.tsx
+++ b/src/components/detail/RecruitFooter.tsx
@@ -1,39 +1,55 @@
+'use client';
+
+import UserChat from '@/components/common/userChat';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { PostContentProps } from '@/types/PostContent';
 import Image from 'next/image';
+import { useState } from 'react';
 
-interface RecruitFooterProps {
-    title: string;
-}
+export default function RecruitFooter({ post }: PostContentProps) {
+    const [showChat, setShowChat] = useState(false);
 
-export default function RecruitFooter({ title }: RecruitFooterProps) {
+    const toggleChat = () => {
+        setShowChat((prev) => !prev);
+    };
+
     return (
-        <footer className="fixed right-0 bottom-0 left-0 w-full bg-white py-5 drop-shadow-2xl">
-            <div className="mx-auto flex max-w-[1240px] items-center justify-between px-4">
-                <div className="flex items-center gap-1.5">
-                    <Badge>동행구함</Badge>
-                    <p className="text-base font-semibold text-black">
-                        {title}
-                    </p>
-                </div>
+        <>
+            <footer className="fixed right-0 bottom-0 left-0 w-full bg-white py-5 drop-shadow-2xl">
+                <div className="mx-auto flex max-w-[1240px] items-center justify-between px-4">
+                    <div className="flex items-center gap-1.5">
+                        <Badge>동행구함</Badge>
+                        <p className="text-base font-semibold text-black">
+                            {post.title}
+                        </p>
+                    </div>
 
-                <div className="flex items-center gap-5">
-                    <Button
-                        variant="outline"
-                        className="h-9 w-[100px] border-[#0ac7e4] text-sm font-semibold text-[#0ac7e4]"
-                    >
-                        <Image
-                            src="/icon/detail/chatIcon.svg"
-                            alt="chat"
-                            width={16}
-                            height={16}
-                            className="mr-1.5"
-                        />
-                        문의하기
-                    </Button>
-                    <Button className="h-9 w-[150px]">참여하기</Button>
+                    <div className="flex items-center gap-5">
+                        <Button
+                            variant="outline"
+                            className="h-9 w-[100px] border-[#0ac7e4] text-sm font-semibold text-[#0ac7e4]"
+                            onClick={toggleChat}
+                        >
+                            <Image
+                                src="/icon/detail/chatIcon.svg"
+                                alt="chat"
+                                width={16}
+                                height={16}
+                                className="mr-1.5"
+                            />
+                            문의하기
+                        </Button>
+                        <Button className="h-9 w-[150px]">참여하기</Button>
+                    </div>
                 </div>
-            </div>
-        </footer>
+            </footer>
+
+            {showChat && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+                    <UserChat post={post} onClose={toggleChat} />
+                </div>
+            )}
+        </>
     );
 }


### PR DESCRIPTION
## 작업 내용
- 상세 페이지에서 '문의하기'를 누르면 나오는 채팅 사이드바를 구현하였습니다.
- 강사님 이야기에 힌트를 얻어서 일단 메세지 데이터에서 유저값을 구분하여 메세지의 색상, 위치가 다르게 보이도록 했습니다.
- 메세지 자체가 없는 경우 채팅을 위한 가이드를 안내하는 별도 ui를 띄웁니다.
- 상세 페이지 글 작성자의 아이디나 평점 등 일부 내용도 데이터 바인딩으로 할당했습니다.

<img width="420" alt="스크린샷 2025-03-25 오전 12 33 26" src="https://github.com/user-attachments/assets/e3efa883-10d3-4659-bb8b-bb6a4c8bba92" />
