### PR TITLE
design: 채팅장 ui 1차 구현

### DIFF
--- a/src/app/[lang]/chat/[id]/page.tsx
+++ b/src/app/[lang]/chat/[id]/page.tsx
@@ -1,0 +1,12 @@
+import ChatList from '@/components/common/ChatList';
+
+export default function ChatPage() {
+    return (
+        <>
+            <div className="fixed inset-x-0 top-0 -z-10 h-full bg-[#F5F6F7]" />
+            <main className="mx-auto h-screen w-full max-w-[580px] bg-white">
+                <ChatList />
+            </main>
+        </>
+    );
+}

--- a/src/app/[lang]/chat/page.tsx
+++ b/src/app/[lang]/chat/page.tsx
@@ -8,7 +8,7 @@ export default function Chat() {
     return (
         <>
             <div className="fixed inset-x-0 top-0 -z-10 h-full bg-[#F5F6F7]" />
-            <main className="mx-auto w-full max-w-[580px] bg-white">
+            <main className="bg-background-light mx-auto max-w-[580px] border-x-1 border-[#E9E9E9]">
                 <header className="px-5 pt-10 pb-[50px]">
                     <h1 className="text-xl font-semibold">대화 목록</h1>
                 </header>

--- a/src/app/[lang]/chat/page.tsx
+++ b/src/app/[lang]/chat/page.tsx
@@ -1,80 +1,31 @@
 import ChatPreview from '@/components/chat/ChatPreview';
+import Link from 'next/link';
+
+// 데이터 생기면 파일도 삭제
+import { chatData } from './tempData';
 
 export default function Chat() {
-    // 임시데이터
-    const chatData = [
-        {
-            id: 1,
-            name: '귀여운동행자',
-            location: '제주도',
-            time: '5분전',
-            message:
-                '안녕하세요. 저도 같은 일정에 제주도 방문 예정이라 연락드렸습니다. 저는 아이ㅣ어아이',
-            unreadChat: 1,
-            userIcon: '',
-        },
-        {
-            id: 2,
-            name: '귀여운동행자',
-            location: '제주도',
-            time: '5분전',
-            message:
-                '안녕하세요. 저도 같은 일정에 제주도 방문 예정이라 연락드렸습니다. 저는 아이ㅣ어아이',
-            unreadChat: 99,
-            userIcon: '',
-        },
-        {
-            id: 3,
-            name: '귀여운동행자',
-            location: '제주도',
-            time: '24.10.12',
-            message:
-                '안녕하세요. 저도 같은 일정에 제주도 방문 예정이라 연락드렸습니다. 저는 아이ㅣ어아이',
-            unreadChat: 0,
-            userIcon: '',
-        },
-        {
-            id: 4,
-            name: '귀여운동행자',
-            location: '제주도',
-            time: '24.10.12',
-            message:
-                '안녕하세요. 저도 같은 일정에 제주도 방문 예정이라 연락드렸습니다. 저는 아이ㅣ어아이',
-            unreadChat: 0,
-            userIcon: '',
-        },
-        {
-            id: 5,
-            name: '귀여운동행자',
-            location: '제주도',
-            time: '24.10.12',
-            message:
-                '안녕하세요. 저도 같은 일정에 제주도 방문 예정이라 연락드렸습니다. 저는 아이ㅣ어아이',
-            unreadChat: 0,
-            userIcon: '',
-        },
-    ];
-
     return (
         <>
-            <div className="flex min-h-screen w-full justify-center bg-[#F5F6F7]">
-                <section className="bg-background-light flex w-full max-w-[580px] flex-col border-x-1 border-[E9E9E9]">
-                    <header className="px-5 pt-10 pb-[50px]">
-                        <h1 className="text-xl font-semibold">대화 목록</h1>
-                    </header>
+            <div className="fixed inset-x-0 top-0 -z-10 h-full bg-[#F5F6F7]" />
+            <main className="mx-auto w-full max-w-[580px] bg-white">
+                <header className="px-5 pt-10 pb-[50px]">
+                    <h1 className="text-xl font-semibold">대화 목록</h1>
+                </header>
 
-                    {/* 채팅 목록 */}
-                    <div className="overflow-y-auto px-4">
-                        <ul className="list-none space-y-[30px] p-0">
-                            {chatData.map((chat) => (
-                                <li key={chat.id}>
+                {/* 채팅 목록 */}
+                <div className="overflow-y-auto px-4">
+                    <ul className="list-none space-y-[30px] p-0">
+                        {chatData.map((chat) => (
+                            <li key={chat.id}>
+                                <Link href={`/chat/${chat.id}`}>
                                     <ChatPreview chat={chat} />
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                </section>
-            </div>
+                                </Link>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </main>
         </>
     );
 }

--- a/src/app/[lang]/chat/page.tsx
+++ b/src/app/[lang]/chat/page.tsx
@@ -1,0 +1,80 @@
+import ChatPreview from '@/components/chat/ChatPreview';
+
+export default function Chat() {
+    // 임시데이터
+    const chatData = [
+        {
+            id: 1,
+            name: '귀여운동행자',
+            location: '제주도',
+            time: '5분전',
+            message:
+                '안녕하세요. 저도 같은 일정에 제주도 방문 예정이라 연락드렸습니다. 저는 아이ㅣ어아이',
+            unreadChat: 1,
+            userIcon: '',
+        },
+        {
+            id: 2,
+            name: '귀여운동행자',
+            location: '제주도',
+            time: '5분전',
+            message:
+                '안녕하세요. 저도 같은 일정에 제주도 방문 예정이라 연락드렸습니다. 저는 아이ㅣ어아이',
+            unreadChat: 99,
+            userIcon: '',
+        },
+        {
+            id: 3,
+            name: '귀여운동행자',
+            location: '제주도',
+            time: '24.10.12',
+            message:
+                '안녕하세요. 저도 같은 일정에 제주도 방문 예정이라 연락드렸습니다. 저는 아이ㅣ어아이',
+            unreadChat: 0,
+            userIcon: '',
+        },
+        {
+            id: 4,
+            name: '귀여운동행자',
+            location: '제주도',
+            time: '24.10.12',
+            message:
+                '안녕하세요. 저도 같은 일정에 제주도 방문 예정이라 연락드렸습니다. 저는 아이ㅣ어아이',
+            unreadChat: 0,
+            userIcon: '',
+        },
+        {
+            id: 5,
+            name: '귀여운동행자',
+            location: '제주도',
+            time: '24.10.12',
+            message:
+                '안녕하세요. 저도 같은 일정에 제주도 방문 예정이라 연락드렸습니다. 저는 아이ㅣ어아이',
+            unreadChat: 0,
+            userIcon: '',
+        },
+    ];
+
+    return (
+        <>
+            <div className="flex min-h-screen w-full justify-center bg-[#F5F6F7]">
+                <section className="bg-background-light flex w-full max-w-[580px] flex-col border-x-1 border-[E9E9E9]">
+                    <header className="px-5 pt-10 pb-[50px]">
+                        <h1 className="text-xl font-semibold">대화 목록</h1>
+                    </header>
+
+                    {/* 채팅 목록 */}
+                    <div className="overflow-y-auto px-4">
+                        <ul className="list-none space-y-[30px] p-0">
+                            {chatData.map((chat) => (
+                                <li key={chat.id}>
+                                    <ChatPreview chat={chat} />
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </section>
+            </div>
+        </>
+    );
+}

--- a/src/app/[lang]/chat/tempData.ts
+++ b/src/app/[lang]/chat/tempData.ts
@@ -1,0 +1,205 @@
+// 임시 데이터들
+export interface ChatProps {
+    chat: {
+        id: number;
+        name: string;
+        location: string;
+        time: string;
+        message: string;
+        unreadChat: number;
+        userIcon: string;
+    };
+}
+export type ChatItem = ChatProps['chat'];
+export const chatData: ChatItem[] = [
+    {
+        id: 1,
+        name: '여행하는몽자',
+        location: '제주도',
+        time: '1분전',
+        message:
+            '제주도 게스트하우스 예약했는데 근처에 맛집 추천해주실 수 있나요?',
+        unreadChat: 3,
+        userIcon: '',
+    },
+    {
+        id: 2,
+        name: '백패커',
+        location: '부산',
+        time: '5분전',
+        message:
+            '부산 해운대 근처에서 같이 여행하실 분 구해요! 사진 찍는 걸 좋아하시면 더 좋아요',
+        unreadChat: 1,
+        userIcon: '',
+    },
+    {
+        id: 3,
+        name: '등산러버',
+        location: '설악산',
+        time: '10분전',
+        message:
+            '이번 주말 설악산 등반하실 분 있나요? 초급자 코스로 계획했습니다',
+        unreadChat: 5,
+        userIcon: '',
+    },
+    {
+        id: 4,
+        name: '맛집탐험가',
+        location: '서울',
+        time: '30분전',
+        message:
+            '홍대 맛집 투어 같이 하실 분 구합니다! 맛있는 거 좋아하시는 분이면 좋겠어요',
+        unreadChat: 2,
+        userIcon: '',
+    },
+    {
+        id: 5,
+        name: '문화여행자',
+        location: '경주',
+        time: '1시간전',
+        message:
+            '경주 고궁 투어 함께해요! 역사에 관심 있으신 분이면 더 좋을 것 같아요',
+        unreadChat: 1,
+        userIcon: '',
+    },
+    {
+        id: 6,
+        name: '카메라맨',
+        location: '강릉',
+        time: '2시간전',
+        message: '강릉 커피거리 투어하실 분 있나요? 인생샷도 찍어드립니다!',
+        unreadChat: 0,
+        userIcon: '',
+    },
+    {
+        id: 7,
+        name: '바다사랑',
+        location: '여수',
+        time: '3시간전',
+        message: '여수 밤바다 구경하면서 맛집 탐방하실 분 찾습니다~',
+        unreadChat: 8,
+        userIcon: '',
+    },
+    {
+        id: 8,
+        name: '한옥스테이',
+        location: '전주',
+        time: '4시간전',
+        message: '전주 한옥마을에서 한복 체험하실 분 구해요! 인생샷 보장합니다',
+        unreadChat: 0,
+        userIcon: '',
+    },
+    {
+        id: 9,
+        name: '산책러',
+        location: '서울',
+        time: '5시간전',
+        message: '한강 따라 자전거 타실 분 있나요? 여의도에서 출발합니다',
+        unreadChat: 2,
+        userIcon: '',
+    },
+    {
+        id: 10,
+        name: '미술관투어',
+        location: '서울',
+        time: '6시간전',
+        message:
+            '북촌 갤러리 투어 함께하실 분 구합니다. 예술 좋아하시는 분이면 좋겠어요',
+        unreadChat: 0,
+        userIcon: '',
+    },
+    {
+        id: 11,
+        name: '섬여행자',
+        location: '통영',
+        time: '어제',
+        message: '통영 동피랑 마을 구경하실 분 있나요? 섬 투어도 계획 중입니다',
+        unreadChat: 4,
+        userIcon: '',
+    },
+    {
+        id: 12,
+        name: '캠핑러버',
+        location: '가평',
+        time: '어제',
+        message: '가평에서 글램핑하실 분 구해요! 바베큐 파티도 준비했습니다',
+        unreadChat: 0,
+        userIcon: '',
+    },
+    {
+        id: 13,
+        name: '식도락여행',
+        location: '대구',
+        time: '어제',
+        message: '대구 서문시장 먹방 투어 함께하실 분! 맛집 리스트 준비했어요',
+        unreadChat: 1,
+        userIcon: '',
+    },
+    {
+        id: 14,
+        name: '올레길걷기',
+        location: '제주도',
+        time: '2일전',
+        message:
+            '제주 올레길 7코스 같이 걸으실 분 구합니다. 중간중간 맛집 들르기도 해요',
+        unreadChat: 0,
+        userIcon: '',
+    },
+    {
+        id: 15,
+        name: '카페투어',
+        location: '광주',
+        time: '2일전',
+        message:
+            '광주 카페거리 투어하실 분 있나요? 분위기 좋은 곳만 선별했습니다',
+        unreadChat: 3,
+        userIcon: '',
+    },
+    {
+        id: 16,
+        name: '축제마니아',
+        location: '진주',
+        time: '3일전',
+        message:
+            '진주 남강유등축제 보러 가실 분 구해요! 야경 사진도 찍을 예정입니다',
+        unreadChat: 0,
+        userIcon: '',
+    },
+    {
+        id: 17,
+        name: '시장구경',
+        location: '부산',
+        time: '3일전',
+        message: '부산 국제시장 구경하실 분! 맛집 투어도 포함입니다',
+        unreadChat: 0,
+        userIcon: '',
+    },
+    {
+        id: 18,
+        name: '템플스테이',
+        location: '해인사',
+        time: '4일전',
+        message: '해인사 템플스테이 참여하실 분 있나요? 2박 3일 일정입니다',
+        unreadChat: 6,
+        userIcon: '',
+    },
+    {
+        id: 19,
+        name: '도보여행',
+        location: '군산',
+        time: '4일전',
+        message:
+            '군산 근대문화거리 투어하실 분 구합니다. 복고풍 사진 찍기 좋아요',
+        unreadChat: 0,
+        userIcon: '',
+    },
+    {
+        id: 20,
+        name: '사진작가',
+        location: '안동',
+        time: '5일전',
+        message: '안동 하회마을 한복 체험하면서 인생샷 찍으실 분 구해요!',
+        unreadChat: 2,
+        userIcon: '',
+    },
+];

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -53,15 +53,15 @@ export default async function RootLayout({
             <body className={`font-pretendard bg-custom-light antialiased`}>
                 <ReduxProvider>
                     <TanstackProviders>
-                        <div
+                        <ThemeToggler colorTheme={isDarkMode} />
+                        <NavBar
+                            className={`bg-custom-light sticky top-0 z-40`}
+                        />
+                        <main
                             className={`mx-auto max-w-[1240px] px-4 sm:px-6 md:px-5`}
                         >
-                            <ThemeToggler colorTheme={isDarkMode} />
-                            <NavBar
-                                className={`bg-custom-light sticky top-0 z-40`}
-                            />
                             {children}
-                        </div>
+                        </main>
                     </TanstackProviders>
                 </ReduxProvider>
             </body>

--- a/src/components/Nav/NavBar.tsx
+++ b/src/components/Nav/NavBar.tsx
@@ -15,12 +15,12 @@ export default function NavBar({ className }: NavProps) {
     return (
         <header
             className={cn(
-                'flex h-18 w-full items-center justify-between',
+                'm-auto flex h-18 w-full items-center justify-between',
                 className,
             )}
         >
             {/* 데스크탑 레이아웃 */}
-            <div className="hidden w-full md:flex md:items-center md:justify-between">
+            <div className="m-auto hidden w-full max-w-[1240px] px-[20px] md:flex md:items-center md:justify-between">
                 <section className="flex items-center gap-3">
                     <Logo />
                     <SearchBar className="bg-neutral-100 dark:bg-neutral-800" />

--- a/src/components/chat/ChatPreview.tsx
+++ b/src/components/chat/ChatPreview.tsx
@@ -1,0 +1,57 @@
+import Image from 'next/image';
+
+interface ChatProps {
+    chat: {
+        id: number;
+        name: string;
+        location: string;
+        time: string;
+        message: string;
+        unreadChat: number;
+        userIcon: string;
+    };
+}
+
+export default function ({ chat }: ChatProps) {
+    return (
+        <article className="flex h-[60px] w-full cursor-pointer items-center px-2">
+            {/* 좌측 대화 프로필 이미지 */}
+            <div className="mr-3.5 h-[60px] w-[60px] flex-shrink-0 overflow-hidden rounded-full bg-gray-200">
+                <Image
+                    src={chat.userIcon || '/placeholder-avatar.png'}
+                    alt={chat.name}
+                    width={60}
+                    height={60}
+                    className="h-full w-full object-cover"
+                />
+            </div>
+
+            <div className="flex min-w-0 flex-1 flex-col justify-center gap-[7px]">
+                {/* 중앙 유저 아이디, 지역 */}
+                <div className="flex items-center">
+                    <div className="text-base font-semibold">{chat.name}</div>
+                    <div className="mx-[6px] text-base font-semibold text-[#333333]">
+                        ·
+                    </div>
+                    <div className="text-xs font-medium text-[#666666]">
+                        {chat.location}
+                    </div>
+                </div>
+                {/* 가장 최근 메세지 미리보기 */}
+                <p className="max-w-[360px] truncate text-sm text-gray-600">
+                    {chat.message}
+                </p>
+            </div>
+
+            {/* 우측 메세지 도착 시간 및 안읽은 메세지 뱃지 */}
+            <div className="ml-2 flex flex-col items-end">
+                <p className="mb-3 text-xs text-[#666666]">{chat.time}</p>
+                {chat.unreadChat > 0 && (
+                    <span className="flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#FF4D4D] px-1.5 text-xs font-medium text-white">
+                        {chat.unreadChat}
+                    </span>
+                )}
+            </div>
+        </article>
+    );
+}

--- a/src/components/chat/ChatPreview.tsx
+++ b/src/components/chat/ChatPreview.tsx
@@ -12,7 +12,7 @@ interface ChatProps {
     };
 }
 
-export default function ({ chat }: ChatProps) {
+export default function ChatPreview({ chat }: ChatProps) {
     return (
         <article className="flex h-[60px] w-full cursor-pointer items-center px-2">
             {/* 좌측 대화 프로필 이미지 */}


### PR DESCRIPTION
## 작업 내용 요약
- 채팅 ui 디자인 작업 진행했습니다.
- 아직 유저 데이터가 구체적이지 않아 각 채팅방을 눌렀을 때 누른 채팅방의 대화 목록만 보이는 로직 등은 아직 구현하지 않았습니다.

## 변경사항
- 지금까지 페이지 배경은 무조건 화이트다를 전제로 작업 진행했었는데, 채팅 창만 전체 회색 배경이 깔려있어서 전체적인 레이아웃 구조를 조금 변경했습니다.

## 스크린샷
<img width="2021" alt="스크린샷 2025-03-27 오전 11 23 35" src="https://github.com/user-attachments/assets/f51b9f59-f34c-4a61-be23-7a667ca9320f" />
