### PR TITLE
refactor: 홈 페이지 케러셀 부분 서버 연결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,5 @@
 import type { NextConfig } from 'next';
 
-
-
-
-
 const nextConfig: NextConfig = {
     reactStrictMode: true, // 개발 중 잠재적 문제를 조기에 발견하기 위한 설정
     // Next.js 에서 이제 디폴트로 관리되어 불필요한 설정이라 주석 처리 하였습니다.
@@ -11,7 +7,14 @@ const nextConfig: NextConfig = {
     compress: true, // 응답 압축으로 성능 향상
     poweredByHeader: false, // 보안을 위해 X-Powered-By 헤더 제거
     images: {
-        remotePatterns: [], // 외부 이미지 도메인 허용 목록 -> domains -> remotePatterns 로 수정 하였습니다.
+        remotePatterns: [
+            {
+                protocol: 'http',
+                hostname: 'localhost',
+                port: '8080', // 포트도 필요하다면 추가합니다. 예: 8080 포트
+                pathname: '/static/**', // 경로 패턴
+            },
+        ], // 외부 이미지 도메인 허용 목록 -> domains -> remotePatterns 로 수정 하였습니다.
         formats: ['image/webp', 'image/avif'], // 최신 이미지 포맷 지원
     },
     // 미들웨어에서 이미 처리하고 있고, 레거시 설정이라 주석처리 하였습니다.

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -3,11 +3,18 @@ import InfiniteScroll from '@/components/home/InfiniteScroll';
 import { TrendingCarousel } from '@/components/home/TrendingCarousel';
 import { Checkbox } from '@/components/ui/checkbox';
 
-export default function Home() {
+export default async function Home() {
+    const res = await fetch('http://localhost:8080/trending', {
+        cache: 'no-store',
+    });
+    const trendingPosts = await res.json();
     return (
         <main>
             {/* 인기 모임 캐러셀 영역 */}
-            <TrendingCarousel className="mt-5 sm:mt-7.5" />
+            <TrendingCarousel
+                className="mt-5 sm:mt-7.5"
+                posts={trendingPosts}
+            />
 
             {/* 필터링 영역 */}
             <h1 className="mt-[75px] mb-[26px] text-2xl font-semibold">

--- a/src/components/home/TrendingCarousel.tsx
+++ b/src/components/home/TrendingCarousel.tsx
@@ -13,13 +13,23 @@ import { cn } from '@/lib';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import trendingPost from '../../../public/data/trending';
-
 interface TrendingCarouselProps {
     className?: string;
+    posts: {
+        id: number;
+        title: string;
+        imageSrc: string;
+        profileImage: string;
+        userName: string;
+        age: string;
+        gender: string;
+        startDate: string;
+        endDate: string;
+        userId: string;
+    }[];
 }
 
-export function TrendingCarousel({ className }: TrendingCarouselProps) {
+export function TrendingCarousel({ posts, className }: TrendingCarouselProps) {
     const isMobile = useMediaQuery('(max-width: 630px)');
 
     return (
@@ -71,7 +81,7 @@ export function TrendingCarousel({ className }: TrendingCarouselProps) {
                 </section>
 
                 <CarouselContent className="gap-1 px-1">
-                    {trendingPost.map((trend, index) => (
+                    {posts.map((trend, index) => (
                         <CarouselItem
                             key={index}
                             className="min-w-[264px] basis-auto sm:min-w-[400px]"


### PR DESCRIPTION
## 작업 내용 요약

- trending carousel 컴포넌트를 home 의 page.tsx 에서 fetch 하여 서버 사이드 랜더링으로 변경
- 기존 trendingpost.ts 에서 받아오지 않도록 수정

