### PR TITLE
design: 작성된 글의 썸네일 부분 추가, 달력들 기능 및 선택 범위 제한 수정

### DIFF
--- a/public/data/trending.ts
+++ b/public/data/trending.ts
@@ -197,13 +197,7 @@ const trendingPost = [
         preferredGender: '무관',
         maxMembers: 5,
         currentMembers: 1,
-        hashtags: [
-            '#해운대',
-            '#광안리',
-            '#감천문화마을',
-            '#자갈치시장',
-            '#부산여행',
-        ],
+        hashtags: ['#광안리', '#감천문화마을', '#자갈치시장', '#부산여행'],
         isDeleted: false,
         participants: [
             {

--- a/src/components/Editor/PostSetupPanel.tsx
+++ b/src/components/Editor/PostSetupPanel.tsx
@@ -116,6 +116,12 @@ export default function PostSetupPanel() {
                                         setValue('filter.startDate', date)
                                     }
                                     initialFocus
+                                    disabled={(date) =>
+                                        date <
+                                        new Date(
+                                            new Date().setHours(0, 0, 0, 0),
+                                        )
+                                    }
                                 />
                             </PopoverContent>
                         </Popover>
@@ -152,9 +158,6 @@ export default function PostSetupPanel() {
                                         date && setValue('filter.endDate', date)
                                     }
                                     initialFocus
-                                    disabled={(date) =>
-                                        startDate ? date < startDate : false
-                                    }
                                 />
                             </PopoverContent>
                         </Popover>
@@ -198,7 +201,10 @@ export default function PostSetupPanel() {
                                     }
                                     initialFocus
                                     disabled={(date) =>
-                                        endDate ? date < endDate : false
+                                        date <
+                                        new Date(
+                                            new Date().setHours(0, 0, 0, 0),
+                                        )
                                     }
                                 />
                             </PopoverContent>

--- a/src/components/common/RecruitPost.tsx
+++ b/src/components/common/RecruitPost.tsx
@@ -4,30 +4,47 @@ import { PostContentProps } from '@/types/PostContent';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { Badge } from '../ui/badge';
+
 //todo : 현재는 낙관적 업데이트를 위한 단순한 id 만 정의 (데이터 바인딩 x )
 
 export default function RecruitPost({ post }: PostContentProps) {
     return (
         <article className="flex flex-col gap-2.5 rounded-xl bg-[#f5f6f7] px-[34px] py-[30px]">
             {/* 헤더 섹션 */}
-            <header className="flex w-full flex-col">
+            <div className="flex w-full flex-col">
                 <Link href={`/detail/${post.id}`}>
-                    <div className="mb-2 flex w-full items-center gap-2">
-                        <span
-                            className={`${post.isGroupOpen ? 'bg-[#fa9b56]' : 'bg-[#999999]'} rounded-[20px] px-3 py-1 text-xs font-semibold text-white`}
-                        >
-                            {post.isGroupOpen ? '동행 구함' : '모집 마감'}
-                        </span>
+                    <div className="relative">
+                        <div className="mb-1.5 flex w-full items-center gap-2">
+                            <Badge
+                                variant={
+                                    post.isGroupOpen ? 'default' : 'disable'
+                                }
+                            >
+                                {post.isGroupOpen ? '동행 구함' : '모집 마감'}
+                            </Badge>
 
-                        {/* 글제목  */}
-                        <h1 className="flex-1 truncate text-xl font-bold text-black">
-                            {post.title}
-                        </h1>
+                            {/* 글제목  */}
+                            <h1 className="flex-1 truncate text-xl font-bold text-black">
+                                {post.title}
+                            </h1>
+                        </div>
+
+                        {/* 썸네일 이미지 */}
+                        {post.imageSrc && (
+                            <div className="absolute top-0 right-0 h-[98px] w-[98px] overflow-hidden rounded-xl">
+                                <Image
+                                    src={post.imageSrc}
+                                    alt="게시글 썸네일"
+                                    fill
+                                    className="object-cover"
+                                />
+                            </div>
+                        )}
                     </div>
 
                     {/* 모집 정보 */}
-
-                    <div className="mb-3.5 flex items-center gap-2.5">
+                    <div className="mb-3 flex items-center gap-2.5">
                         <span className="text-sm text-[#333333]">
                             {/* 날짜 빼서 며칠 일정인지 계산 로직 필요 */}
                             {`${post.startDate} - ${post.endDate} (${'n'}일)`}
@@ -58,7 +75,7 @@ export default function RecruitPost({ post }: PostContentProps) {
                                 key={index}
                                 className="relative rounded px-1.5 py-1"
                             >
-                                <div className="text-bg-sky-blue z-10 text-[15px] leading-[19.1px] font-medium tracking-[0.47px] whitespace-nowrap">
+                                <div className="text-sky-blue z-10 text-[15px] leading-[19.1px] font-medium tracking-[0.47px] whitespace-nowrap">
                                     {hashtag}
                                 </div>
                                 <div className="bg-sky-blue absolute top-0 left-0 h-[27px] w-full rounded opacity-[0.08]" />
@@ -71,12 +88,12 @@ export default function RecruitPost({ post }: PostContentProps) {
                         {extractPreview(post.content)}
                     </p>
                 </Link>
-            </header>
+            </div>
 
             <hr className="mb-3.5 h-px w-full border-0 bg-gray-200" />
 
             {/* 유저 프로필 */}
-            <section className="flex w-full flex-col items-start justify-between gap-4 md:flex-row md:items-center md:gap-2">
+            <div className="flex w-full flex-col items-start justify-between gap-4 md:flex-row md:items-center md:gap-2">
                 <Link href={`/profile/${post.userId}`}>
                     {/* 아이콘 */}
                     <div className="flex items-center gap-3">
@@ -112,12 +129,11 @@ export default function RecruitPost({ post }: PostContentProps) {
                     </div>
                 </Link>
 
-                {/* 상호작용 버튼 */}
+                {/*낙관적 업데이트 찜 버튼*/}
                 <div className="flex w-full items-center gap-2 md:w-auto">
-                    {/*낙관적 업데이트 찜 버튼*/}
                     <Like id={post.id} className={`px-0`} />
                 </div>
-            </section>
+            </div>
         </article>
     );
 }

--- a/src/components/home/CreatePost.tsx
+++ b/src/components/home/CreatePost.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+
+export default function CreatePost() {
+    return (
+        <div className="col-span-full mx-auto w-[380px]">
+            <div className="mt-40 mb-[329px] flex flex-col items-center gap-[30px]">
+                <p className="text-center text-base font-medium text-gray-500">
+                    조건에 부합하는 동행이 없어요.
+                    <br />
+                    내가 원하는 동행을 만들어보세요!
+                </p>
+
+                <Link href={'/write'} className="w-[380px]">
+                    <Button className="h-[59px] w-[380px] text-lg font-bold">
+                        내가 원하는 동행글 작성하기
+                    </Button>
+                </Link>
+            </div>
+        </div>
+    );
+}

--- a/src/components/home/InfiniteScroll.tsx
+++ b/src/components/home/InfiniteScroll.tsx
@@ -51,7 +51,7 @@ export default function InfiniteScroll() {
 
     if (isError) {
         return (
-            <div className="col-span-full mx-auto mt-40 flex flex-col items-center gap-5">
+            <div className="col-span-full mx-auto mt-40 mb-[329px] flex flex-col items-center gap-5">
                 <p className="text-base font-medium text-gray-500">
                     일시적인 오류가 발생했어요
                 </p>
@@ -102,6 +102,7 @@ export default function InfiniteScroll() {
                     </div>
                 </div>
             )}
+
             {/* 첫 로딩을 끝낸 이후 데이터가 있으면 게시글 작성 버튼을 fixed로 띄웁니다. */}
             {!isLoading && !hasNoData && <CreatePostWindow />}
 

--- a/src/components/home/InfiniteScroll.tsx
+++ b/src/components/home/InfiniteScroll.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef } from 'react';
 // api 생기면 삭제
 import trendingPost from '../../../public/data/trending';
 import LoadingThreeDots from '../common/LoadingThreeDots';
-import { Button } from '../ui/button';
+import CreatePost from './CreatePost';
 import CreatePostWindow from './CreatePostWindow';
 
 export default function InfiniteScroll() {
@@ -50,16 +50,8 @@ export default function InfiniteScroll() {
     }, [isInView, fetchNextPage, isFetchingNextPage, hasNextPage]);
 
     if (isError) {
-        return (
-            <div className="col-span-full mx-auto mt-40 mb-[329px] flex flex-col items-center gap-5">
-                <p className="text-base font-medium text-gray-500">
-                    일시적인 오류가 발생했어요
-                </p>
-                <Button onClick={() => window.location.reload()}>
-                    새로고침
-                </Button>
-            </div>
-        );
+        console.error('Error fetching posts data');
+        return <CreatePost />;
     }
 
     const hasNoData = data?.pages[0]?.length === 0;
@@ -84,24 +76,8 @@ export default function InfiniteScroll() {
                 </motion.div>
             ))}
 
-            {/* api 생기면 다시 활성화, 글이 없는 경우 띄울 Ui */}
-            {hasNoData && (
-                <div className="col-span-full mx-auto w-full max-w-[380px]">
-                    <div className="mt-40 mb-[329px] flex flex-col items-center gap-[30px]">
-                        <p className="text-center text-base font-medium text-gray-500">
-                            조건에 부합하는 동행이 없어요.
-                            <br />
-                            내가 원하는 동행을 만들어보세요!
-                        </p>
-
-                        <Button className="h-[59px] w-full">
-                            <span className="text-lg font-bold">
-                                내가 원하는 동행글 작성하기
-                            </span>
-                        </Button>
-                    </div>
-                </div>
-            )}
+            {/* 글이 없는 경우 띄울 Ui */}
+            {hasNoData && <CreatePost />}
 
             {/* 첫 로딩을 끝낸 이후 데이터가 있으면 게시글 작성 버튼을 fixed로 띄웁니다. */}
             {!isLoading && !hasNoData && <CreatePostWindow />}

--- a/src/components/home/filter/DateFilter.tsx
+++ b/src/components/home/filter/DateFilter.tsx
@@ -15,18 +15,20 @@ import { setDateAction } from '@/redux/slices/filterSlice';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import Image from 'next/image';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 export const DateFilter = () => {
     const date = useAppSelector((state) => state.filter.date);
     const dispatch = useAppDispatch();
     const isMobile = useMediaQuery('(max-width: 1200px)');
+    const [open, setOpen] = useState(false);
 
     const fromDate = date?.from ? new Date(date.from) : null;
     const toDate = date?.to ? new Date(date.to) : null;
 
     const resetSelection = useCallback(() => {
         dispatch(setDateAction(undefined));
+        setOpen(false);
     }, [dispatch]);
 
     if (isMobile) {
@@ -41,7 +43,7 @@ export const DateFilter = () => {
     }
 
     return (
-        <Popover>
+        <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
                 <Button
                     variant={'outline'}
@@ -99,13 +101,20 @@ export const DateFilter = () => {
                     />
 
                     {/* 초기화 버튼 */}
-                    <div className="mb-2 w-[250px]">
+                    <div className="mb-2 flex w-[250px] gap-3">
                         <Button
                             variant={'reset'}
                             onClick={resetSelection}
-                            className="h-10 w-full rounded-lg border-1 text-sm"
+                            className="h-10 w-1/2 rounded-lg border-1 text-sm"
                         >
                             초기화
+                        </Button>
+                        <Button
+                            variant={'default'}
+                            onClick={() => setOpen(false)}
+                            className="h-10 w-1/2 rounded-lg text-sm"
+                        >
+                            적용
                         </Button>
                     </div>
                 </div>


### PR DESCRIPTION
## 변경사항

- 무한스크롤 섹션의 카드 컴포넌트들에 썸네일이 없었는데, 추가했습니다.
- 데스크탑 달력 부분에서 적용을 선택하면 달력 창이 닫히도록 추가했습니다.
- 글 작성 페이지에서 기존의 마감기한 선택 범위 제한을 없애고, 과거의 날짜를 선택할 수 없도록 추가했습니다.
