### PR TITLE
feat: 로그인 상태관리, GNB 상태

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -70,7 +70,8 @@ export default async function RootLayout({
     //----------------------------------------
 
     //-------------------유저 정보 SSR ----------------------------
-    const NEST_BFF_URL = process.env.NEXT_BFF_URL;
+    const NEST_BFF_URL =
+        process.env.NEXT_BFF_URL || 'https://gateway.wego-travel.click';
     let user = null;
 
     try {
@@ -83,9 +84,11 @@ export default async function RootLayout({
 
         if (res.ok) {
             user = await res.json();
+            console.log(user);
         } else {
             // 로그인 안된 상태로 처리
             user = null;
+            console.log(res);
         }
     } catch (err) {
         // 서버가 죽었거나 네트워크 문제일 경우 ( fetch 는 !res.ok 를 throw 하지 않는다!! ) -> 로그인상태 x

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -69,6 +69,18 @@ export default async function RootLayout({
     const currentLang = pathLocale || localeFromCookie || 'ko';
     //----------------------------------------
 
+    //-------------------유저 정보 SSR ----------------------------
+    const NEST_BFF_URL = process.env.NEXT_BFF_URL;
+    const cookieHeader = headersList.get('cookie') ?? '';
+
+    const userRes = await fetch(`${NEST_BFF_URL}/api/user/me`, {
+        headers: {
+            cookie: cookieHeader,
+        },
+        cache: 'no-store',
+    });
+    const user = userRes.ok ? await userRes.json() : null;
+
     return (
         <html
             lang={currentLang}
@@ -79,7 +91,7 @@ export default async function RootLayout({
             )}
         >
             <body className={cn(`font-pretendard bg-custom-light antialiased`)}>
-                <ReduxProvider>
+                <ReduxProvider user={user}>
                     <TanstackProviders>
                         <NavBar
                             isDarkMode={isDarkMode}

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -71,15 +71,27 @@ export default async function RootLayout({
 
     //-------------------유저 정보 SSR ----------------------------
     const NEST_BFF_URL = process.env.NEXT_BFF_URL;
-    const cookieHeader = headersList.get('cookie') ?? '';
+    let user = null;
 
-    const userRes = await fetch(`${NEST_BFF_URL}/api/user/me`, {
-        headers: {
-            cookie: cookieHeader,
-        },
-        cache: 'no-store',
-    });
-    const user = userRes.ok ? await userRes.json() : null;
+    try {
+        const res = await fetch(`${NEST_BFF_URL}/api/user/me`, {
+            headers: {
+                cookie: (await headers()).get('cookie') || '',
+            },
+            cache: 'no-store',
+        });
+
+        if (res.ok) {
+            user = await res.json();
+        } else {
+            // 로그인 안된 상태로 처리
+
+            console.warn(`user/me 응답 상태: ${res.status}`);
+        }
+    } catch (err) {
+        // 서버가 죽었거나 네트워크 문제일 경우 ( fetch 는 !res.ok 를 throw 하지 않는다!! )
+        console.error('user/me 네트워크 오류:', err);
+    }
 
     return (
         <html

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -85,8 +85,7 @@ export default async function RootLayout({
             user = await res.json();
         } else {
             // 로그인 안된 상태로 처리
-
-            console.warn(`user/me 응답 상태: ${res.status}`);
+            user = null;
         }
     } catch (err) {
         // 서버가 죽었거나 네트워크 문제일 경우 ( fetch 는 !res.ok 를 throw 하지 않는다!! ) -> 로그인상태 x

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -89,7 +89,7 @@ export default async function RootLayout({
             console.warn(`user/me 응답 상태: ${res.status}`);
         }
     } catch (err) {
-        // 서버가 죽었거나 네트워크 문제일 경우 ( fetch 는 !res.ok 를 throw 하지 않는다!! )
+        // 서버가 죽었거나 네트워크 문제일 경우 ( fetch 는 !res.ok 를 throw 하지 않는다!! ) -> 로그인상태 x
         console.error('user/me 네트워크 오류:', err);
     }
 

--- a/src/components/Nav/AuthNav.tsx
+++ b/src/components/Nav/AuthNav.tsx
@@ -1,0 +1,37 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+interface AuthNavProps {
+    kakaoId?: string;
+}
+
+export default function AuthNav({ kakaoId }: AuthNavProps) {
+    return (
+        <div
+            className={
+                'flex flex-col items-center gap-1 text-center text-base font-semibold text-[#666666] md:ml-5 md:flex-row md:gap-7.5'
+            }
+        >
+            <Link href={'#'} className={'cursor-pointer'}>
+                찜한 동행
+            </Link>
+            <Link href={'#'} className={'cursor-pointer'}>
+                대화목록
+            </Link>
+            <Link href={'#'} className={'cursor-pointer'}>
+                알림
+            </Link>
+            <Link
+                href={`/profile/${kakaoId}`}
+                className="border-sky-blue h-8 w-8 cursor-pointer rounded-full border"
+            >
+                <Image
+                    src={'/icon/profile/defaultProfile.svg'}
+                    alt={'user'}
+                    width={32}
+                    height={32}
+                />
+            </Link>
+        </div>
+    );
+}

--- a/src/components/Nav/Hamburger.tsx
+++ b/src/components/Nav/Hamburger.tsx
@@ -1,18 +1,26 @@
 'use client';
 
 import LoginBtn from '@/components/Btn/LoginBtn';
+import AuthNav from '@/components/Nav/AuthNav';
 import ThemeToggler from '@/components/ThemeToggler/DarkModeToggler';
 import {
     DropdownMenu,
     DropdownMenuContent,
-    DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib';
 import { Menu, X } from 'lucide-react';
 import { useRef, useState } from 'react';
 
-export default function Hamburger({ isDarkMode }: { isDarkMode: boolean }) {
+export default function Hamburger({
+    isDarkMode,
+    isAuthenticated,
+    kakaoId,
+}: {
+    isDarkMode: boolean;
+    isAuthenticated: boolean;
+    kakaoId?: string;
+}) {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const menuRef = useRef(null);
 
@@ -46,16 +54,17 @@ export default function Hamburger({ isDarkMode }: { isDarkMode: boolean }) {
                     />
                 </div>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="center" className="w-auto">
-                <DropdownMenuItem>
+            <DropdownMenuContent align="center" className="w-auto px-2 py-1">
+                {isAuthenticated ? (
+                    <div className="flex justify-center">
+                        <AuthNav kakaoId={kakaoId} />
+                    </div>
+                ) : (
                     <LoginBtn />
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                    <ThemeToggler
-                        colorTheme={isDarkMode}
-                        className={'mx-auto'}
-                    />
-                </DropdownMenuItem>
+                )}
+                <div className="flex justify-center">
+                    <ThemeToggler colorTheme={isDarkMode} className="mx-auto" />
+                </div>
             </DropdownMenuContent>
         </DropdownMenu>
     );

--- a/src/components/Nav/NavBar.tsx
+++ b/src/components/Nav/NavBar.tsx
@@ -2,10 +2,12 @@
 
 import LoginBtn from '@/components/Btn/LoginBtn';
 import MultiLingualToggler from '@/components/MultiLingual/MultiLingualToggler';
+import AuthNav from '@/components/Nav/AuthNav';
 import Hamburger from '@/components/Nav/Hamburger';
 import Logo from '@/components/Nav/Logo';
 import { SearchBar } from '@/components/Nav/SearchBar';
 import ThemeToggler from '@/components/ThemeToggler/DarkModeToggler';
+import { useSession } from '@/hooks/useSession';
 import { cn } from '@/lib';
 
 interface NavProps {
@@ -14,6 +16,8 @@ interface NavProps {
 }
 
 export default function NavBar({ className, isDarkMode }: NavProps) {
+    const { isAuthenticated, kakaoId } = useSession();
+
     return (
         <header
             className={cn(
@@ -31,7 +35,12 @@ export default function NavBar({ className, isDarkMode }: NavProps) {
                 <section className="flex items-center">
                     <ThemeToggler colorTheme={isDarkMode} />
 
-                    <LoginBtn />
+                    {isAuthenticated ? (
+                        <AuthNav kakaoId={kakaoId} />
+                    ) : (
+                        <LoginBtn />
+                    )}
+
                     <div className="w-[20px]" />
                     <MultiLingualToggler />
                 </section>
@@ -39,7 +48,11 @@ export default function NavBar({ className, isDarkMode }: NavProps) {
 
             {/* 모바일 레이아웃 */}
             <div className="flex w-full items-center justify-between md:hidden">
-                <Hamburger isDarkMode={isDarkMode} />
+                <Hamburger
+                    isDarkMode={isDarkMode}
+                    isAuthenticated={isAuthenticated}
+                    kakaoId={kakaoId}
+                />
 
                 <section className="absolute left-1/2 -translate-x-1/2 transform">
                     <Logo />

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useAppSelector } from '@/redux/hooks';
+
+/**
+ * GNB 구조 때문에 모든 페이지에서 로그인 상태 store 조회가 필요합니다.
+ * SSR -> initialstate 에 주입된 유저 로그인 세션을 불러오는 커스텀 훅 입니다.
+ * 가벼운 값들이라 펼쳐서 모두 반환하도록 구성했습니다.
+ */
+export const useSession = () => {
+    const user = useAppSelector((state) => state.user);
+
+    return {
+        isAuthenticated: user.isAuthenticated,
+        nickname: user.info?.nickname,
+        email: user.info?.email,
+        kakaoId: user.info?.kakaoId,
+    };
+};

--- a/src/redux/ReduxProvider.tsx
+++ b/src/redux/ReduxProvider.tsx
@@ -7,14 +7,24 @@ import { Provider } from 'react-redux';
 interface Props {
     children: React.ReactNode;
     initialLang?: string;
+    user?: {
+        kakaoId: string;
+        nickname: string;
+        email?: string;
+    };
 }
 
-const ReduxProvider: React.FC<Props> = ({ children }) => {
+const ReduxProvider: React.FC<Props> = ({ children, user }: Props) => {
     const storeRef = useRef<AppStore | null>(null);
 
     if (!storeRef.current) {
         // 초기 상태로 스토어 생성 (필요한 초기값 설정)
-        storeRef.current = initializeStore({});
+        storeRef.current = initializeStore({
+            user: {
+                info: user || null,
+                isAuthenticated: !!user,
+            },
+        });
     }
     return <Provider store={storeRef.current}>{children}</Provider>;
 };

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -1,0 +1,33 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+export interface UserState {
+    info: {
+        kakaoId: string;
+        nickname: string;
+        email?: string;
+    } | null;
+    isAuthenticated: boolean;
+}
+
+const initialState: UserState = {
+    info: null,
+    isAuthenticated: false,
+};
+
+const userSlice = createSlice({
+    name: 'user',
+    initialState,
+    reducers: {
+        setUserInfo: (state, action: PayloadAction<UserState['info']>) => {
+            state.info = action.payload;
+            state.isAuthenticated = !!action.payload;
+        },
+        clearUserInfo: (state) => {
+            state.info = null;
+            state.isAuthenticated = false;
+        },
+    },
+});
+
+export const { setUserInfo, clearUserInfo } = userSlice.actions;
+export default userSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import filterReducer from './slices/filterSlice';
+import userReducer from './slices/userSlice';
 
 /**
  * 팩토리 패턴으로 변경 -> 사용자마다 스토어 격리 보장
@@ -8,7 +9,7 @@ import filterReducer from './slices/filterSlice';
  */
 export function initializeStore(initialState = {}) {
     return configureStore({
-        reducer: { filter: filterReducer }, // '나와 함께 할 동행 찾기' 필터링 슬라이스
+        reducer: { filter: filterReducer, user: userReducer }, // '나와 함께 할 동행 찾기' 필터링 슬라이스
         preloadedState: initialState,
     });
 }


### PR DESCRIPTION
## 작업 내용 요약

- 현재 Mocking 상태로 BFF 를 설정해 두었고, 항상 Guest 로 로그인된 상태를 반환하도록 수정 하였습니다.
- layout.tsx 에서 SSR 로 api/user/me 를 조회하여 유저가 로그인 된 상태인지 검사합니다.
- 해당 데이터를 Redux 스토어에 초기값으로 주입하였고, 로그인 상태를 불러오는 useSession 훅 작성하였습니다.
- Nav 컴포넌트에서 useSession 을 사용하여 유저가 로그인 된 상태의 UI 를 조건부 랜더링 하였습니다.

## 기타 참고사항

- 로그인 이후 다크모드 버튼 위치가 다시 애매해졌습니다. 

## 스크린샷
 - Redux dev tools
  ![image](https://github.com/user-attachments/assets/5b888f42-5773-4090-ad76-50990c14c5c0)
- 데스크탑 뷰
  ![image](https://github.com/user-attachments/assets/d0f05173-7a9a-48f0-8f4a-1ffa124b22db)
- 모바일 뷰
  ![image](https://github.com/user-attachments/assets/d4768a9b-06de-4d4b-a37a-399b2be03c94)

