### PR TITLE
feat: 프로필 편집 창 유효성 검사 추가

### DIFF
--- a/src/components/profile/ProfileEditor.tsx
+++ b/src/components/profile/ProfileEditor.tsx
@@ -164,10 +164,7 @@ export default function ProfileEditor({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent
-                variant="noOverlay"
-                className="w-[500px] overflow-visible border border-[#E0E0E0] p-0 shadow-[0_0_25px_rgba(0,0,0,0.15)]"
-            >
+            <DialogContent className="w-[500px] overflow-visible border border-[#E0E0E0] p-0 shadow-[0_0_25px_rgba(0,0,0,0.15)]">
                 <DialogHeader className="flex h-[47px] items-center justify-between border-b [border-bottom-style:solid] border-[#e9e9e9] px-[30px] py-2.5">
                     <DialogTitle className="w-full text-center text-base font-bold text-black">
                         프로필 수정하기

--- a/src/components/profile/ProfileEditor.tsx
+++ b/src/components/profile/ProfileEditor.tsx
@@ -159,6 +159,7 @@ export default function ProfileEditor({
         formValues.birthYear,
         formValues.birthMonth,
         formValues.birthDay,
+        formValues,
         setValue,
     ]);
 

--- a/src/components/profile/ProfileEditor.tsx
+++ b/src/components/profile/ProfileEditor.tsx
@@ -239,17 +239,29 @@ export default function ProfileEditor({
                             <input
                                 type="number"
                                 placeholder="YYYY"
-                                value={user.birthYear ?? ''} // Add null coalescing operator
+                                value={user.birthYear ?? ''}
                                 onChange={(e) => {
+                                    // 출생 연도
+                                    const userInput = e.target.value;
+                                    const YEAR_START = 0;
+                                    const YEAR_END = 2025;
+                                    if (
+                                        userInput &&
+                                        (parseInt(userInput) < YEAR_START ||
+                                            parseInt(userInput) > YEAR_END ||
+                                            userInput.length > 4)
+                                    )
+                                        return;
                                     setUser({
                                         ...user,
-                                        birthYear: e.target.value
-                                            ? parseInt(e.target.value)
+                                        birthYear: userInput
+                                            ? parseInt(userInput)
                                             : null,
                                     });
                                 }}
                                 // 넘버 인풋의 기본 화살표 버튼을 제거
                                 className="number-arrow-hide w-12 bg-transparent text-center text-base font-medium text-black outline-none placeholder:text-[#999999]"
+                                maxLength={4}
                             />
                             <span className="text-base font-extralight text-[#999999]">
                                 /
@@ -259,14 +271,28 @@ export default function ProfileEditor({
                                 placeholder="MM"
                                 value={user.birthMonth ?? ''}
                                 onChange={(e) => {
+                                    // 출생 월
+                                    const userInput = e.target.value;
+                                    const MONTH_START = 1;
+                                    const MONTH_END = 12;
+                                    if (parseInt(userInput) < 9) {
+                                    }
+                                    if (
+                                        userInput &&
+                                        (parseInt(userInput) < MONTH_START ||
+                                            parseInt(userInput) > MONTH_END ||
+                                            userInput.length > 2)
+                                    )
+                                        return;
                                     setUser({
                                         ...user,
-                                        birthMonth: e.target.value
-                                            ? parseInt(e.target.value)
+                                        birthMonth: userInput
+                                            ? parseInt(userInput)
                                             : null,
                                     });
                                 }}
                                 className="number-arrow-hide w-8 bg-transparent text-center text-base font-medium text-black outline-none placeholder:text-[#999999]"
+                                maxLength={2}
                             />
                             <span className="text-base font-extralight text-[#999999]">
                                 /
@@ -276,14 +302,26 @@ export default function ProfileEditor({
                                 placeholder="DD"
                                 value={user.birthDay ?? ''}
                                 onChange={(e) => {
+                                    // 출생 일
+                                    const userInput = e.target.value;
+                                    const DAY_START = 1;
+                                    const DAY_END = 31;
+                                    if (
+                                        userInput &&
+                                        (parseInt(userInput) < DAY_START ||
+                                            parseInt(userInput) > DAY_END ||
+                                            userInput.length > 2)
+                                    )
+                                        return;
                                     setUser({
                                         ...user,
-                                        birthDay: e.target.value
-                                            ? parseInt(e.target.value)
+                                        birthDay: userInput
+                                            ? parseInt(userInput)
                                             : null,
                                     });
                                 }}
                                 className="number-arrow-hide w-8 bg-transparent text-center text-base font-medium text-black outline-none placeholder:text-[#999999]"
+                                maxLength={2}
                             />
                         </div>
                     </div>

--- a/src/components/profile/ProfileEditor.tsx
+++ b/src/components/profile/ProfileEditor.tsx
@@ -1,28 +1,102 @@
 'use client';
 
-import Image from 'next/image';
-import { useEffect, useState } from 'react';
-
-import { Button } from '../../components/ui/button';
+import { Button } from '@/components/ui/button';
 import {
     Dialog,
     DialogContent,
     DialogHeader,
     DialogTitle,
-} from '../../components/ui/dialog';
-import { Label } from '../../components/ui/label';
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { zodResolver } from '@hookform/resolvers/zod';
+import Image from 'next/image';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
 
-interface User {
-    id: string;
-    nickname: string;
-    email: string;
-    gender: 'male' | 'female' | undefined;
-    birthYear: number | null;
-    birthMonth: number | null;
-    birthDay: number | null;
-    userIntroduce: string;
-    profileImage: string;
-}
+const userSchema = z.object({
+    id: z.string(),
+    nickname: z
+        .string()
+        .min(1, { message: '별명을 작성해주세요.' })
+        .refine((value) => !value.includes(' '), {
+            message: '공백은 사용할 수 없습니다.',
+        })
+        .refine(
+            (value) => {
+                const koreanRegex = /[가-힣]/;
+                const englishRegex = /[a-zA-Z]/;
+                const mixedRegex = /^[가-힣a-zA-Z]+$/;
+
+                if (!mixedRegex.test(value)) return false;
+
+                const hasKorean = koreanRegex.test(value);
+                const englishMatches = value.match(englishRegex)?.length || 0;
+
+                return hasKorean || englishMatches >= 2;
+            },
+            {
+                message:
+                    '한글 완성형 또는 2글자 이상의 영문을 포함해야 합니다.',
+            },
+        ),
+    email: z.string().email(),
+    gender: z
+        .enum(['male', 'female'])
+        .nullable()
+        .refine((value) => value !== null, {
+            message: '내 프로필을 완성하면 동행원을 찾을 수 있어요.',
+        }),
+    birthYear: z
+        .number({
+            required_error: '내 프로필을 완성하면 동행원을 찾을 수 있어요.',
+            invalid_type_error: '숫자만 입력해주세요.',
+        })
+        .nullable()
+        .refine((value) => value !== undefined, {
+            message: '내 프로필을 완성하면 동행원을 찾을 수 있어요.',
+        })
+        .refine((value) => !value || (value >= 1900 && value <= 2025), {
+            message: '올바른 연도를 입력해주세요',
+        }),
+    birthMonth: z
+        .number({
+            required_error: '내 프로필을 완성하면 동행원을 찾을 수 있어요.',
+            invalid_type_error: '숫자만 입력해주세요.',
+        })
+        .nullable()
+        .refine((value) => value !== undefined, {
+            message: '내 프로필을 완성하면 동행원을 찾을 수 있어요.',
+        })
+        .refine(
+            (value) =>
+                value === undefined ||
+                (value !== null && value >= 1 && value <= 12),
+            {
+                message: '올바른 월을 입력해주세요',
+            },
+        ),
+    birthDay: z
+        .number({
+            invalid_type_error: '숫자만 입력해주세요.',
+        })
+        .nullable()
+        .refine((value) => value !== undefined, {
+            message: '내 프로필을 완성하면 동행원을 찾을 수 있어요.',
+        })
+        .refine(
+            (value) =>
+                value === undefined ||
+                (value !== null && value >= 1 && value <= 31),
+            {
+                message: '올바른 일을 입력해주세요',
+            },
+        ),
+    userIntroduce: z.string(),
+    profileImage: z.string(),
+});
+
+type UserSchema = z.infer<typeof userSchema>;
 
 interface ProfileEditorProps {
     open: boolean;
@@ -33,31 +107,60 @@ export default function ProfileEditor({
     open,
     onOpenChange,
 }: ProfileEditorProps) {
-    const [user, setUser] = useState<User>({
-        id: 'user123',
-        nickname: '귀여운 동행자',
-        email: 'cute@kakao.com',
-        gender: undefined,
-        birthYear: null,
-        birthMonth: null,
-        birthDay: null,
-        userIntroduce: '제주도 여행중',
-        profileImage: '/image/dogProfile.png',
+    const {
+        register,
+        handleSubmit,
+        formState: { errors, isValid },
+        setValue,
+        watch,
+    } = useForm<UserSchema>({
+        resolver: zodResolver(userSchema),
+        defaultValues: {
+            id: 'user123',
+            nickname: '귀여운 동행자',
+            email: 'cute@kakao.com',
+            gender: undefined,
+            birthYear: undefined,
+            birthMonth: undefined,
+            birthDay: undefined,
+            userIntroduce: '제주도 여행중',
+            profileImage: '/image/dogProfile.png',
+        },
+        mode: 'onChange',
     });
 
-    // 에러 상태 추가
-    const [errors, setErrors] = useState({
-        gender: false,
-        birth: false,
-    });
+    const formValues = watch();
 
-    // 유효성 검사
+    const onSubmit = (data: UserSchema) => {
+        alert(JSON.stringify(data));
+    };
+
+    const removeImage = () => {
+        setValue('profileImage', '/icon/profile/defaultProfile.svg');
+    };
+
     useEffect(() => {
-        setErrors({
-            gender: !user.gender,
-            birth: !user.birthYear || !user.birthMonth || !user.birthDay,
-        });
-    }, [user]);
+        const { birthYear, birthMonth, birthDay } = formValues;
+
+        if (birthYear && birthMonth && birthDay) {
+            const date = new Date(birthYear, birthMonth - 1, birthDay);
+            const isValidDate =
+                date.getFullYear() === birthYear &&
+                date.getMonth() === birthMonth - 1 &&
+                date.getDate() === birthDay;
+
+            if (!isValidDate) {
+                setValue('birthYear', null);
+                setValue('birthMonth', null);
+                setValue('birthDay', null);
+            }
+        }
+    }, [
+        formValues.birthYear,
+        formValues.birthMonth,
+        formValues.birthDay,
+        setValue,
+    ]);
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
@@ -79,7 +182,7 @@ export default function ProfileEditor({
                                 <Image
                                     className="rounded-full bg-gray-100 object-cover"
                                     alt="Profile"
-                                    src={user.profileImage}
+                                    src={formValues.profileImage}
                                     fill
                                 />
                             </div>
@@ -98,13 +201,7 @@ export default function ProfileEditor({
                                 <Button
                                     variant="ghost"
                                     className="h-auto p-0"
-                                    onClick={() => {
-                                        setUser({
-                                            ...user,
-                                            profileImage:
-                                                '/icon/profile/defaultProfile.svg',
-                                        });
-                                    }}
+                                    onClick={removeImage}
                                 >
                                     <span className="text-xs font-medium text-[#999999]">
                                         사진 제거
@@ -116,19 +213,20 @@ export default function ProfileEditor({
                         {/* 별명 설정 */}
                         <div className="flex w-[314px] flex-col gap-5">
                             <div className="flex flex-col gap-2.5">
-                                <Label className="text-base font-bold text-black">
-                                    별명
-                                </Label>
+                                <div className="flex items-center gap-2">
+                                    <Label className="text-base font-bold text-black">
+                                        별명
+                                    </Label>
+                                    {errors.nickname && (
+                                        <span className="ml-auto text-xs text-[#FF0000]">
+                                            {errors.nickname.message}
+                                        </span>
+                                    )}
+                                </div>
                                 <div className="flex items-center gap-2.5 rounded-xl bg-[#f5f6f7] px-4 py-2.5">
                                     <input
                                         type="text"
-                                        value={user.nickname}
-                                        onChange={(e) =>
-                                            setUser({
-                                                ...user,
-                                                nickname: e.target.value,
-                                            })
-                                        }
+                                        {...register('nickname')}
                                         className="w-full bg-transparent text-base font-medium text-black outline-none"
                                     />
                                 </div>
@@ -141,14 +239,12 @@ export default function ProfileEditor({
                                     이메일
                                 </Label>
                                 <div className="flex h-11 items-center gap-2.5 rounded-xl bg-[#f5f6f7] px-4 py-2.5">
-                                    <div className="flex items-center gap-2.5 rounded-xl bg-[#f5f6f7] py-2.5">
-                                        <input
-                                            type="email"
-                                            value={user.email}
-                                            readOnly
-                                            className="w-full bg-transparent text-base font-normal text-[#999999] outline-none"
-                                        />
-                                    </div>
+                                    <input
+                                        type="email"
+                                        {...register('email')}
+                                        readOnly
+                                        className="w-full bg-transparent text-base font-normal text-[#999999] outline-none"
+                                    />
                                 </div>
                             </div>
                         </div>
@@ -163,60 +259,30 @@ export default function ProfileEditor({
                             </Label>
                             {errors.gender && (
                                 <span className="ml-auto text-xs text-[#FF0000]">
-                                    내 프로필을 완성하면 동행원을 찾을 수
-                                    있어요.
+                                    {errors.gender.message}
                                 </span>
                             )}
                         </div>
                         <div className="flex gap-10">
                             <div className="flex items-center gap-1.5">
-                                <div className="relative flex items-center">
-                                    <input
-                                        type="radio"
-                                        name="gender"
-                                        id="male"
-                                        value="male"
-                                        checked={user.gender === 'male'}
-                                        onChange={() => {
-                                            setUser({
-                                                ...user,
-                                                gender: 'male',
-                                            });
-                                        }}
-                                        className="h-5 w-5 cursor-pointer appearance-none rounded-full border border-[#D9D9D9] bg-white checked:border-[5px] checked:border-[#0ac7e4]"
-                                    />
-                                </div>
-                                <Label
-                                    htmlFor="male"
-                                    className="cursor-pointer text-base font-medium text-black"
-                                >
-                                    남자
-                                </Label>
+                                <input
+                                    type="radio"
+                                    {...register('gender')}
+                                    value="male"
+                                    id="male"
+                                    className="h-5 w-5 cursor-pointer appearance-none rounded-full border border-[#D9D9D9] bg-white checked:border-[5px] checked:border-[#0ac7e4]"
+                                />
+                                <Label htmlFor="male">남자</Label>
                             </div>
-
                             <div className="flex items-center gap-1.5">
-                                <div className="relative flex items-center">
-                                    <input
-                                        type="radio"
-                                        name="gender"
-                                        id="female"
-                                        value="female"
-                                        checked={user.gender === 'female'}
-                                        onChange={() => {
-                                            setUser({
-                                                ...user,
-                                                gender: 'female',
-                                            });
-                                        }}
-                                        className="h-5 w-5 cursor-pointer appearance-none rounded-full border border-[#D9D9D9] bg-white checked:border-[5px] checked:border-[#0ac7e4]"
-                                    />
-                                </div>
-                                <Label
-                                    htmlFor="female"
-                                    className="cursor-pointer text-base font-medium text-black"
-                                >
-                                    여자
-                                </Label>
+                                <input
+                                    type="radio"
+                                    {...register('gender')}
+                                    value="female"
+                                    id="female"
+                                    className="h-5 w-5 cursor-pointer appearance-none rounded-full border border-[#D9D9D9] bg-white checked:border-[5px] checked:border-[#0ac7e4]"
+                                />
+                                <Label htmlFor="female">여자</Label>
                             </div>
                         </div>
                     </div>
@@ -228,100 +294,58 @@ export default function ProfileEditor({
                                 생년월일
                                 <span className="text-[#0ac7e4]">*</span>
                             </Label>
-                            {errors.birth && (
+                            {(errors.birthYear ||
+                                errors.birthMonth ||
+                                errors.birthDay) && (
                                 <span className="ml-auto text-xs text-[#FF0000]">
-                                    내 프로필을 완성하면 동행원을 찾을 수
-                                    있어요.
+                                    {errors.birthYear?.message ||
+                                        errors.birthMonth?.message ||
+                                        errors.birthDay?.message}
                                 </span>
                             )}
                         </div>
                         <div className="flex items-center justify-center gap-[30px] rounded-xl bg-[#f5f6f7] px-4 py-2.5">
                             <input
-                                type="number"
+                                type="text"
                                 placeholder="YYYY"
-                                value={user.birthYear ?? ''}
-                                onChange={(e) => {
-                                    // 출생 연도
-                                    const userInput = e.target.value;
-                                    const YEAR_START = 0;
-                                    const YEAR_END = 2025;
-                                    if (
-                                        userInput &&
-                                        (parseInt(userInput) < YEAR_START ||
-                                            parseInt(userInput) > YEAR_END ||
-                                            userInput.length > 4)
-                                    )
-                                        return;
-                                    setUser({
-                                        ...user,
-                                        birthYear: userInput
-                                            ? parseInt(userInput)
-                                            : null,
-                                    });
-                                }}
-                                // 넘버 인풋의 기본 화살표 버튼을 제거
-                                className="number-arrow-hide w-12 bg-transparent text-center text-base font-medium text-black outline-none placeholder:text-[#999999]"
                                 maxLength={4}
+                                {...register('birthYear', {
+                                    setValueAs: (value) =>
+                                        value === ''
+                                            ? undefined
+                                            : parseInt(value, 10),
+                                })}
+                                className="w-12 bg-transparent text-center text-base font-medium text-black outline-none placeholder:text-[#999999]"
                             />
                             <span className="text-base font-extralight text-[#999999]">
                                 /
                             </span>
                             <input
-                                type="number"
+                                type="text"
                                 placeholder="MM"
-                                value={user.birthMonth ?? ''}
-                                onChange={(e) => {
-                                    // 출생 월
-                                    const userInput = e.target.value;
-                                    const MONTH_START = 1;
-                                    const MONTH_END = 12;
-                                    if (parseInt(userInput) < 9) {
-                                    }
-                                    if (
-                                        userInput &&
-                                        (parseInt(userInput) < MONTH_START ||
-                                            parseInt(userInput) > MONTH_END ||
-                                            userInput.length > 2)
-                                    )
-                                        return;
-                                    setUser({
-                                        ...user,
-                                        birthMonth: userInput
-                                            ? parseInt(userInput)
-                                            : null,
-                                    });
-                                }}
-                                className="number-arrow-hide w-8 bg-transparent text-center text-base font-medium text-black outline-none placeholder:text-[#999999]"
                                 maxLength={2}
+                                {...register('birthMonth', {
+                                    setValueAs: (value) =>
+                                        value === ''
+                                            ? undefined
+                                            : parseInt(value, 10),
+                                })}
+                                className="w-8 bg-transparent text-center text-base font-medium text-black outline-none placeholder:text-[#999999]"
                             />
                             <span className="text-base font-extralight text-[#999999]">
                                 /
                             </span>
                             <input
-                                type="number"
+                                type="text"
                                 placeholder="DD"
-                                value={user.birthDay ?? ''}
-                                onChange={(e) => {
-                                    // 출생 일
-                                    const userInput = e.target.value;
-                                    const DAY_START = 1;
-                                    const DAY_END = 31;
-                                    if (
-                                        userInput &&
-                                        (parseInt(userInput) < DAY_START ||
-                                            parseInt(userInput) > DAY_END ||
-                                            userInput.length > 2)
-                                    )
-                                        return;
-                                    setUser({
-                                        ...user,
-                                        birthDay: userInput
-                                            ? parseInt(userInput)
-                                            : null,
-                                    });
-                                }}
-                                className="number-arrow-hide w-8 bg-transparent text-center text-base font-medium text-black outline-none placeholder:text-[#999999]"
                                 maxLength={2}
+                                {...register('birthDay', {
+                                    setValueAs: (value) =>
+                                        value === ''
+                                            ? undefined
+                                            : parseInt(value, 10),
+                                })}
+                                className="w-8 bg-transparent text-center text-base font-medium text-black outline-none placeholder:text-[#999999]"
                             />
                         </div>
                     </div>
@@ -335,13 +359,7 @@ export default function ProfileEditor({
                             <input
                                 type="text"
                                 placeholder="간단하게 나를 소개해 보세요."
-                                value={user.userIntroduce}
-                                onChange={(e) => {
-                                    setUser({
-                                        ...user,
-                                        userIntroduce: e.target.value,
-                                    });
-                                }}
+                                {...register('userIntroduce')}
                                 className="w-full bg-transparent text-base font-medium text-black outline-none placeholder:text-[#999999]"
                             />
                         </div>
@@ -368,7 +386,14 @@ export default function ProfileEditor({
                         >
                             취소
                         </Button>
-                        <Button className="h-[52px] flex-1">수정하기</Button>
+
+                        <Button
+                            onClick={handleSubmit(onSubmit)}
+                            variant={isValid ? 'default' : 'darkGray'}
+                            className="h-[52px] flex-1"
+                        >
+                            수정하기
+                        </Button>
                     </div>
                 </div>
             </DialogContent>

--- a/src/components/profile/ReviewEditor.tsx
+++ b/src/components/profile/ReviewEditor.tsx
@@ -56,10 +56,7 @@ export default function ReviewEditor({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent
-                variant="noOverlay"
-                className="h-[714px] w-[500px] border border-[#E0E0E0] p-0 shadow-[0_0_15px_rgba(0,0,0,0.06)]"
-            >
+            <DialogContent className="h-[714px] w-[500px] border border-[#E0E0E0] p-0 shadow-[0_0_15px_rgba(0,0,0,0.06)]">
                 <DialogHeader className="flex h-[47px] items-center justify-between border-b [border-bottom-style:solid] border-[#e9e9e9] px-[30px] py-2.5">
                     <DialogTitle className="w-full text-center text-base font-bold">
                         동행 소감 남기기

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,7 +37,8 @@ function DialogOverlay({
         <DialogPrimitive.Overlay
             data-slot="dialog-overlay"
             className={cn(
-                'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80',
+                // 디자인 요청대로 bg-black/50을 bg-transparent로 변경
+                'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-transparent',
                 className,
             )}
             {...props}
@@ -48,18 +49,15 @@ function DialogOverlay({
 function DialogContent({
     className,
     children,
-    variant = 'default',
     ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
-    variant?: 'default' | 'noOverlay';
-}) {
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
     return (
         <DialogPortal data-slot="dialog-portal">
-            {variant === 'default' && <DialogOverlay />}
+            <DialogOverlay />
             <DialogPrimitive.Content
                 data-slot="dialog-content"
                 className={cn(
-                    'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:max-w-lg',
+                    'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
                     className,
                 )}
                 {...props}


### PR DESCRIPTION
## 작업 내용 요약

- 프로필 편집 창에서 useState 기반 상태 관리에서 react-hook-form, zod를 통한 폼 관리 방식으로 전환하였습니다. 
- 로직을 생각해보니 실질적으로 회원가입 폼 검사와 거의 유사하게 동작해야하고 관리할 것이 많아져, 변경을 고려했습니다.
- 모달 창을 띄운 상태에서 스크롤이 잠기도록 했습니다.
- 모달 창을 띄웠어도 뒷 배경이 완전히 투명한 것은 디자이너 요구사항이라 의도된 것입니다.

## 변경사항

아래 내용을 유효성 검사로 오류 메시지 추가하여 사용자에게 안내

**별명**
- 한글 완성형(ㅇ, ㅏ같은 자음 모음 단독 입력 불가), 1글자 이상
- 영문으로 입력시 2글자 이상
- 한글+영문 조합 허용
 

**성별**
- 필수


**생년월일**
- 필수, 날짜 형식 검사


**상태메세지**
- 선택 필드


## 기타 참고사항

- 제출시 현재는 alert로 폼 데이터를 볼 수 있도록 해놨습니다.
- 사진 업로드 기능은 아직 추가하지 않았습니다.

## 스크린샷
<img width="859" alt="스크린샷 2025-04-02 오후 4 36 30" src="https://github.com/user-attachments/assets/f143c0d0-e570-49db-9fd3-9ae1527c44d8" />


