### PR TITLE
refactor: home detail

### DIFF
--- a/src/app/[lang]/detail/[id]/page.tsx
+++ b/src/app/[lang]/detail/[id]/page.tsx
@@ -5,19 +5,33 @@ import UserProfile from '@/components/detail/UserProfile';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
 
-import trendingPost from '../../../../../public/data/trending';
-
 type Params = { id: string };
 
-interface TestPageProps {
+interface DetailPageProps {
     params: Promise<Params>;
 }
 
-export default async function DetailPage({ params }: TestPageProps) {
+export default async function DetailPage({ params }: DetailPageProps) {
     const { id } = await params;
-    const post = trendingPost.find((post) => post.id === +id);
-    if (!post) {
-        notFound();
+    const NEXT_PUBLIC_NEST_BFF_URL = process.env.NEXT_PUBLIC_NEST_BFF_URL;
+    let post = null;
+
+    try {
+        const res = await fetch(
+            `${NEXT_PUBLIC_NEST_BFF_URL}/api/detail/${id}`,
+            {
+                cache: 'no-cache',
+            },
+        );
+
+        if (!res.ok) {
+            if (res.status === 404) notFound();
+        }
+
+        post = await res.json();
+    } catch (error) {
+        console.error('네트워크 끊김 fetch 실패', error);
+        throw new Error('데이터 로딩 실패');
     }
 
     return (
@@ -26,7 +40,7 @@ export default async function DetailPage({ params }: TestPageProps) {
             <section>
                 <div className="relative rounded-xl md:h-75 md:w-full">
                     <Image
-                        src={post.imageSrc}
+                        src={post.thumbnailUrl}
                         fill
                         className={`object-cover`}
                         alt={`배경사진`}
@@ -38,11 +52,11 @@ export default async function DetailPage({ params }: TestPageProps) {
                 <div>
                     <h1 className={`mb-1 text-2xl font-bold`}>{post.title} </h1>
                     <div className="flex items-center text-sm text-[#666666]">
-                        <span>조회수 {post.view}</span>
+                        <span>조회수 5</span>
                         <div className="mx-2.5 h-2.5 w-px bg-neutral-400"></div>
-                        <span>찜 {post.bookMark}</span>
+                        <span>찜 2</span>
                         <div className="mx-2.5 h-2.5 w-px bg-neutral-400"></div>
-                        <span>댓글 {post.commentCount}</span>
+                        <span>댓글 3</span>
                     </div>
                 </div>
                 <Like className={`my-auto px-0`} id={post.id} />

--- a/src/components/Btn/KAKAOLogin.tsx
+++ b/src/components/Btn/KAKAOLogin.tsx
@@ -4,8 +4,8 @@ import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-const NEST_BFF_URL =
-    process.env.NEST_BFF_URL || 'https://gateway.wego-travel.click';
+const NEXT_PUBLIC_NEST_BFF_URL =
+    process.env.NEXT_PUBLIC_NEST_BFF_URL || 'https://gateway.wego-travel.click';
 
 export default function KAKAOLogin() {
     const params = useParams(); // 지원하지 않는 언어인 경우 기본값으로 한국어 사용
@@ -36,7 +36,7 @@ export default function KAKAOLogin() {
 
     const handleClick = () => {
         // 유저를 서버로 이동
-        window.location.href = `${NEST_BFF_URL}/api/user/kakao/authorize`;
+        window.location.href = `${NEXT_PUBLIC_NEST_BFF_URL}/api/user/kakao/authorize`;
     };
 
     //lang 이 "ko"나 "en"이 아닐 경우에도 fallback "ko"를 기준으로 번역합니다

--- a/src/components/detail/JsonToHtml.tsx
+++ b/src/components/detail/JsonToHtml.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import CustomBulletList from '@/components/Editor/CustomBulletList';
 import CustomOrderedList from '@/components/Editor/CustomOrderedList';
 import { CustomHeading, CustomLink } from '@/components/Editor/Tiptap';

--- a/src/components/detail/JsonToHtmlWrapper.tsx
+++ b/src/components/detail/JsonToHtmlWrapper.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+const DynamicJsonToHtml = dynamic(
+    () => import('@/components/detail/JsonToHtml'),
+    {
+        ssr: false,
+        loading: () => (
+            //JavaScript 파일이 다운로드되는 동안 표시 될 UI 입니다.
+            <div className="bg-sky-blue/50 h-40 animate-pulse rounded"></div>
+        ),
+    },
+);
+
+/**
+ * SSR로 content를 넘기도록 리팩토링한 이후에 제이슨을 html로 랜더링하는 함수가 서버에서 실행되는 문제 발생
+ * ('use client') 사용해도 방어가 되지 않아 dinamic 과 suspense 를 적용 하였습니다.
+ * @param content
+ * @constructor
+ */
+export default function JsonToHtmlWrapper({ content }: { content: string }) {
+    return (
+        <Suspense
+            fallback={
+                //컴포넌트 마운트 이전까지 보일 UI 입니다.
+                <div className="bg-sky-blue/50 h-40 animate-pulse rounded"></div>
+            }
+        >
+            <DynamicJsonToHtml content={content} />
+        </Suspense>
+    );
+}

--- a/src/components/detail/KakaoMapViewer.tsx
+++ b/src/components/detail/KakaoMapViewer.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { BikeIcon, MountainIcon } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type Props = {
+    lat: number;
+    lng: number;
+};
+
+/**
+ * 코드 중복이 있지만 훅으로 분리하지 않고 우선 글 작성 페이지 카카오 지도 로직을 끌고와서 수정했습니다.
+ * @param placeName
+ * @param lat
+ * @param lng
+ * @constructor
+ */
+export default function KakaoMapViewer({ lat, lng }: Props) {
+    const mapRef = useRef<HTMLDivElement>(null);
+    const mapInstance = useRef<kakao.maps.Map | null>(null);
+    const [showBicycle, setShowBicycle] = useState(false);
+    const [showTerrain, setShowTerrain] = useState(false);
+
+    const initializeMap = useCallback(() => {
+        if (!mapRef.current) return;
+
+        const { kakao } = window;
+        const latLng = new kakao.maps.LatLng(lat, lng);
+
+        const map = new kakao.maps.Map(mapRef.current, {
+            center: latLng,
+            level: 5,
+            scrollwheel: false,
+        });
+        mapInstance.current = map;
+
+        const markerImage = new kakao.maps.MarkerImage(
+            '/icon/marker.svg',
+            new kakao.maps.Size(80, 80),
+            { offset: new kakao.maps.Point(40, 78) },
+        );
+
+        const marker = new kakao.maps.Marker({
+            position: latLng,
+            image: markerImage,
+        });
+        marker.setMap(map);
+
+        if (showBicycle) {
+            map.addOverlayMapTypeId(kakao.maps.MapTypeId.BICYCLE);
+        }
+        if (showTerrain) {
+            map.addOverlayMapTypeId(kakao.maps.MapTypeId.TERRAIN);
+        }
+    }, [lat, lng, showBicycle, showTerrain]);
+
+    useEffect(() => {
+        if (!lat || !lng) return;
+
+        if (window.kakao && window.kakao.maps) {
+            initializeMap();
+            return;
+        }
+
+        const script = document.createElement('script');
+        script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY}&autoload=false&libraries=services`;
+        script.onload = () => {
+            window.kakao.maps.load(initializeMap);
+        };
+        script.onerror = () => {
+            console.error('카카오 SDK 로드 실패');
+        };
+        document.head.appendChild(script);
+    }, [initializeMap, lat, lng]);
+
+    // 지도 위 오버레이 적용 (토글 후 동작)
+    useEffect(() => {
+        const map = mapInstance.current;
+        if (!map || !window.kakao || !window.kakao.maps) return;
+
+        if (showBicycle) {
+            map.addOverlayMapTypeId(window.kakao.maps.MapTypeId.BICYCLE);
+        } else {
+            map.removeOverlayMapTypeId(window.kakao.maps.MapTypeId.BICYCLE);
+        }
+
+        if (showTerrain) {
+            map.addOverlayMapTypeId(window.kakao.maps.MapTypeId.TERRAIN);
+        } else {
+            map.removeOverlayMapTypeId(window.kakao.maps.MapTypeId.TERRAIN);
+        }
+    }, [showBicycle, showTerrain]);
+
+    return (
+        <div className="relative h-[400px] w-full rounded border shadow">
+            <div ref={mapRef} className="h-full w-full" />
+
+            {/* 토글 버튼 */}
+            <div className="absolute top-2 right-2 z-10 flex flex-col gap-2">
+                <button
+                    type="button"
+                    onClick={() => setShowBicycle((prev) => !prev)}
+                    className={`flex items-center gap-1 rounded border px-2 py-1 text-sm ${showBicycle ? 'bg-sky-blue' : 'bg-white dark:bg-black'}`}
+                >
+                    <BikeIcon size={20} />
+                </button>
+                <button
+                    type="button"
+                    onClick={() => setShowTerrain((prev) => !prev)}
+                    className={`flex items-center gap-1 rounded border px-2 py-1 text-sm ${showTerrain ? 'bg-sky-blue' : 'bg-white dark:bg-black'}`}
+                >
+                    <MountainIcon size={20} />
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/detail/PostContent.tsx
+++ b/src/components/detail/PostContent.tsx
@@ -1,8 +1,11 @@
-import JsonToHtml from '@/components/detail/JsonToHtml';
-import { PostContentProps } from '@/types/PostContent';
+import { dateFormat } from '@/lib';
+import { calculateDays } from '@/lib/calculateDays';
+import { DetailPost } from '@/types/DetailPost';
 import Image from 'next/image';
 
-export default function PostContent({ post }: PostContentProps) {
+import JsonToHtmlWrapper from './JsonToHtmlWrapper';
+
+export default function PostContent({ post }: { post: DetailPost }) {
     return (
         <>
             <div className="mt-12.5 mb-[60px] flex flex-col items-start gap-[30px]">
@@ -28,7 +31,7 @@ export default function PostContent({ post }: PostContentProps) {
                                     </h3>
                                 </div>
                                 <p className="text-base font-medium">
-                                    {post.location}
+                                    {post.location.placeName}
                                 </p>
                             </div>
 
@@ -47,8 +50,14 @@ export default function PostContent({ post }: PostContentProps) {
                                     </h3>
                                 </div>
                                 <div className="text-base font-medium">
-                                    {/* TODO 날짜 계산해서 n일 로직은 아직 못 넣었어요,,🥲 */}
-                                    {post.startDate} - {post.endDate} ({'n'}일)
+                                    {dateFormat(post.filter.startDate, false)} -{' '}
+                                    {dateFormat(post.filter.endDate, false)} (
+                                    {calculateDays(
+                                        post.filter.startDate,
+
+                                        post.filter.endDate,
+                                    )}
+                                    일)
                                 </div>
                             </div>
 
@@ -67,7 +76,7 @@ export default function PostContent({ post }: PostContentProps) {
                                     </h3>
                                 </div>
                                 <div className="text-base font-medium">
-                                    {post.category}
+                                    {post.filter.groupTheme}
                                 </div>
                             </div>
 
@@ -112,11 +121,11 @@ export default function PostContent({ post }: PostContentProps) {
                                 <div className="text-base font-medium">
                                     <div className="inline-flex items-center gap-[18px]">
                                         <span className="text-[#333333]">
-                                            {post.ageRange}
+                                            {post.filter.age[0]}
                                         </span>
                                         <div className="h-2.5 w-px bg-gray-300" />
                                         <span className="text-[#333333]">
-                                            {post.preferredGender}
+                                            {post.filter.gender}
                                         </span>
                                     </div>
                                 </div>
@@ -126,7 +135,7 @@ export default function PostContent({ post }: PostContentProps) {
 
                     <div className="mt-5 flex flex-col gap-5">
                         <div className="flex flex-wrap gap-2">
-                            {post.hashtags.map((tag, index) => (
+                            {post.tags.map((tag, index) => (
                                 <span
                                     key={index}
                                     className="rounded bg-[#00afc9]/[0.08] px-1.5 py-1 text-[15px] text-[#00afc9]"
@@ -137,7 +146,7 @@ export default function PostContent({ post }: PostContentProps) {
                         </div>
 
                         <article className="text-lg leading-[130%] font-medium text-[#333333]">
-                            <JsonToHtml content={post.content} />
+                            <JsonToHtmlWrapper content={post.content} />
                         </article>
                     </div>
                 </div>

--- a/src/components/detail/PostLocation.tsx
+++ b/src/components/detail/PostLocation.tsx
@@ -1,10 +1,7 @@
+import KakaoMapViewer from '@/components/detail/KakaoMapViewer';
 import Image from 'next/image';
 
-interface PostLocationProps {
-    location: string;
-}
-
-export default function PostLocation({ location }: PostLocationProps) {
+export default function PostLocation() {
     return (
         <>
             <div className="flex flex-col items-start gap-5">
@@ -12,9 +9,7 @@ export default function PostLocation({ location }: PostLocationProps) {
                     동행지 위치
                 </h2>
 
-                <div className="relative flex h-[450px] w-full items-center justify-center overflow-hidden rounded-md bg-gray-100">
-                    <span className="text-gray-500">지도 영역</span>
-                </div>
+                <KakaoMapViewer lat={35.1004} lng={129.0359} />
 
                 <div className="flex w-full items-center gap-3">
                     <Image
@@ -25,7 +20,7 @@ export default function PostLocation({ location }: PostLocationProps) {
                         className="text-gray-700"
                     />
                     <p className="text-base leading-5 font-medium text-[#333333]">
-                        {location}
+                        {'부산 광역시 중구'}
                     </p>
                 </div>
             </div>

--- a/src/components/detail/PostLocation.tsx
+++ b/src/components/detail/PostLocation.tsx
@@ -1,7 +1,15 @@
 import KakaoMapViewer from '@/components/detail/KakaoMapViewer';
 import Image from 'next/image';
 
-export default function PostLocation() {
+export default function PostLocation({
+    placeName,
+    lat,
+    lng,
+}: {
+    placeName: string;
+    lat: number;
+    lng: number;
+}) {
     return (
         <>
             <div className="flex flex-col items-start gap-5">
@@ -9,7 +17,7 @@ export default function PostLocation() {
                     동행지 위치
                 </h2>
 
-                <KakaoMapViewer lat={35.1004} lng={129.0359} />
+                <KakaoMapViewer lat={lat} lng={lng} />
 
                 <div className="flex w-full items-center gap-3">
                     <Image
@@ -20,7 +28,7 @@ export default function PostLocation() {
                         className="text-gray-700"
                     />
                     <p className="text-base leading-5 font-medium text-[#333333]">
-                        {'부산 광역시 중구'}
+                        {placeName}
                     </p>
                 </div>
             </div>

--- a/src/components/detail/RecruitFooter.tsx
+++ b/src/components/detail/RecruitFooter.tsx
@@ -20,7 +20,11 @@ export default function RecruitFooter({ post }: PostContentProps) {
             <footer className="fixed right-0 bottom-0 left-0 z-40 w-full bg-white py-5 drop-shadow-2xl">
                 <div className="mx-auto flex max-w-[1240px] items-center justify-between px-4">
                     <div className="flex items-center gap-1.5">
-                        <Badge>동행구함</Badge>
+                        {new Date() < new Date(post.endDate) ? (
+                            <Badge>동행구함</Badge>
+                        ) : (
+                            <Badge variant={'disable'}>동행마감</Badge>
+                        )}
                         <p className="text-base font-semibold text-black">
                             {post.title}
                         </p>

--- a/src/components/detail/TabSection.tsx
+++ b/src/components/detail/TabSection.tsx
@@ -39,7 +39,11 @@ export default function TabSection({ post }: { post: DetailPost }) {
             </section>
             {/*지도 섹션*/}
             <section ref={locationAreaRef} className="scroll-mt-40">
-                <PostLocation />
+                <PostLocation
+                    placeName={post.location.placeName}
+                    lat={post.location.lat}
+                    lng={post.location.lng}
+                />
             </section>
             {/*todo: 멤버 소개 섹션*/}
             <section ref={memberAreaRef} className="scroll-mt-40">

--- a/src/components/detail/TabSection.tsx
+++ b/src/components/detail/TabSection.tsx
@@ -6,11 +6,10 @@ import PostInput from '@/components/detail/PostInput';
 import PostLocation from '@/components/detail/PostLocation';
 import PostReview from '@/components/detail/PostReview';
 import ScrollSpy from '@/components/detail/ScrollSpy';
+import { DetailPost } from '@/types/DetailPost';
 import { useRef } from 'react';
 
-import { TrendingPost } from '../../../public/data/trending';
-
-export default function TabSection({ post }: { post: TrendingPost }) {
+export default function TabSection({ post }: { post: DetailPost }) {
     // 스크롤 할 ref 위치 기록
     const contentAreaRef = useRef<HTMLDivElement>(null);
     const locationAreaRef = useRef<HTMLDivElement>(null);
@@ -51,6 +50,7 @@ export default function TabSection({ post }: { post: TrendingPost }) {
                     <p className={`animate-spin`}> 요</p>
                 </div>
             </section>
+            {/*todo: 댓글과 리뷰도 ajax요청으로 변경 해야 할 것 같습니다.*/}
             {/*댓글 섹션*/}
             <section ref={commentAreaRef} className={`mt-15 scroll-mt-40`}>
                 <PostComment />

--- a/src/components/detail/TabSection.tsx
+++ b/src/components/detail/TabSection.tsx
@@ -40,7 +40,7 @@ export default function TabSection({ post }: { post: TrendingPost }) {
             </section>
             {/*지도 섹션*/}
             <section ref={locationAreaRef} className="scroll-mt-40">
-                <PostLocation location={post.location} />
+                <PostLocation />
             </section>
             {/*todo: 멤버 소개 섹션*/}
             <section ref={memberAreaRef} className="scroll-mt-40">

--- a/src/components/detail/UserProfile.tsx
+++ b/src/components/detail/UserProfile.tsx
@@ -1,7 +1,18 @@
-import { PostContentProps } from '@/types/PostContent';
+import { convertAgeRange } from '@/lib/convertAgeRange';
 import Image from 'next/image';
 
-export default function UserProfile({ post }: PostContentProps) {
+interface UserProfileProps {
+    post: {
+        userName: string;
+        profileImage: string;
+        statusMessage: string;
+        userAge: number;
+        userGender: string;
+        userRating: number;
+    };
+}
+
+export default function UserProfile({ post }: UserProfileProps) {
     return (
         <>
             {/* 유저 프로필 영역 */}
@@ -27,10 +38,12 @@ export default function UserProfile({ post }: PostContentProps) {
                                 {post.statusMessage}
                             </p>
                             <div className="h-1.5 w-px bg-gray-300" />
-                            <p className="text-xs text-[#666666]">{post.age}</p>
+                            <p className="text-xs text-[#666666]">
+                                {convertAgeRange(post.userAge)}
+                            </p>
                             <div className="h-1.5 w-px bg-gray-300" />
                             <p className="text-xs text-[#666666]">
-                                {post.gender}
+                                {post.userGender}
                             </p>
                         </div>
                     </div>
@@ -46,7 +59,8 @@ export default function UserProfile({ post }: PostContentProps) {
                             height={16}
                         />
                         <p className="text-base font-semibold">
-                            {`${post.rating.toFixed(1)}(${post.reviewCount})`}
+                            {/*todo:레이팅총개수 */}
+                            {`${post.userRating.toFixed(1)}(10)`}
                         </p>
                     </div>
 

--- a/src/components/home/TrendingCarousel.tsx
+++ b/src/components/home/TrendingCarousel.tsx
@@ -10,21 +10,33 @@ import {
 } from '@/components/ui/carousel';
 import useMediaQuery from '@/hooks/useMediaQuery';
 import { cn } from '@/lib';
+import { convertAgeRange } from '@/lib/convertAgeRange';
 import Image from 'next/image';
 import Link from 'next/link';
+
+import dateFormat from '../../lib/dateFormat';
 
 interface TrendingCarouselProps {
     className?: string;
     posts: {
         id: number;
         title: string;
-        imageSrc: string;
+        filter: {
+            startDate: string;
+            endDate: string;
+            gender: string;
+            age: string[];
+        };
+        location: {
+            placeName: string;
+            lat: number;
+            lng: number;
+        };
+        thumbnailUrl: string;
         profileImage: string;
         userName: string;
-        age: string;
-        gender: string;
-        startDate: string;
-        endDate: string;
+        userAge: number;
+        userGender: string;
         userId: string;
     }[];
 }
@@ -92,7 +104,7 @@ export function TrendingCarousel({ posts, className }: TrendingCarouselProps) {
                                     className="relative h-full w-full"
                                 >
                                     <Image
-                                        src={trend.imageSrc}
+                                        src={trend.thumbnailUrl}
                                         alt="제주소녀"
                                         fill
                                         className="object-cover"
@@ -121,7 +133,8 @@ export function TrendingCarousel({ posts, className }: TrendingCarouselProps) {
                                                 {trend.userName}
                                             </span>
                                             <span className="text-sm">
-                                                {trend.age} · {trend.gender}
+                                                {convertAgeRange(trend.userAge)}{' '}
+                                                · {trend.userGender}
                                             </span>
                                         </Link>
                                         <div className="flex-grow"></div>
@@ -141,8 +154,15 @@ export function TrendingCarousel({ posts, className }: TrendingCarouselProps) {
                                                 height={14}
                                             />
                                             <span>
-                                                {trend.startDate} -{' '}
-                                                {trend.endDate}
+                                                {dateFormat(
+                                                    trend.filter.startDate,
+                                                    false,
+                                                )}{' '}
+                                                -{' '}
+                                                {dateFormat(
+                                                    trend.filter.endDate,
+                                                    false,
+                                                )}
                                             </span>
                                         </div>
                                     </div>

--- a/src/lib/calculateDays.ts
+++ b/src/lib/calculateDays.ts
@@ -4,7 +4,10 @@
  * @param endDate 여행 종료일 (Date 객체)
  * @returns 여행 일수 (시작일과 종료일 포함)
  */
-export const calculateDays = (startDate: Date, endDate: Date): number => {
+export const calculateDays = (
+    startDate: string | Date,
+    endDate: string | Date,
+): number => {
     // 입력값 유효성 검사
     if (!startDate || !endDate) return 0;
 

--- a/src/types/DetailPost.ts
+++ b/src/types/DetailPost.ts
@@ -1,0 +1,33 @@
+export interface DetailPost {
+    id: number;
+    title: string;
+    filter: {
+        startDate: string; // ISO 형식
+        endDate: string;
+        deadlineDate: string;
+        deadlineTime: string; // '18:00' 같은 문자열
+        groupTheme: string;
+        groupSize: string;
+        gender: string;
+        age: string[]; // 예: ['20대']
+    };
+    location: {
+        placeName: string;
+        lat: number;
+        lng: number;
+    };
+    content: string;
+    thumbnailUrl: string;
+    tags: string[]; // 예: ['#여행', '#맛집']
+    currentMembers: number;
+    maxMembers: number;
+
+    // 유저 정보
+    userId: string;
+    userName: string;
+    profileImage: string;
+    statusMessage: string;
+    userAge: number;
+    userGender: string;
+    userRating: number;
+}


### PR DESCRIPTION
## 작업 내용 요약

- 캐러셀 부분도 무한 스크롤 포스트와 똑같이 변수명, 데이터 구조 통일했습니다.  
- 상세 페이지에 카카오 지도 추가하였습니다. 
- 팁탭 json 을 html로 랜더링하는 함수를 Next 서버에서 실행을 계속 시도해서 dinamic , suspense 로 클라이언트에서만 로드 되도록 수정했습니다.  
- SEO 에 게시글이 노출되지 않는 문제가 발생할 것 같은데 이후에 고려하면 좋을 것 같습니다. 

## 스크린샷

![image](https://github.com/user-attachments/assets/a2ff20b7-5c2c-4cfd-81da-07db5aaee7c2)

