### PR TITLE
fix: deadline date time

### DIFF
--- a/src/components/common/RecruitPost.tsx
+++ b/src/components/common/RecruitPost.tsx
@@ -15,7 +15,9 @@ export interface PostContentProps {
 }
 
 export default function RecruitPost({ post }: PostContentProps) {
-    const isGroupOpen = new Date(post.filter.endDate) > new Date();
+    const isGroupOpen =
+        new Date(`${post.filter.deadlineDate}T${post.filter.deadlineTime}:00`) >
+        new Date();
 
     return (
         <article className="flex flex-col gap-2.5 rounded-xl bg-[#f5f6f7] px-[34px] py-[30px]">

--- a/src/components/common/RecruitPost.tsx
+++ b/src/components/common/RecruitPost.tsx
@@ -15,9 +15,7 @@ export interface PostContentProps {
 }
 
 export default function RecruitPost({ post }: PostContentProps) {
-    const isGroupOpen =
-        new Date(`${post.filter.deadlineDate}T${post.filter.deadlineTime}:00`) >
-        new Date();
+    const isGroupOpen = new Date(post.filter.deadlineDate) > new Date();
 
     return (
         <article className="flex flex-col gap-2.5 rounded-xl bg-[#f5f6f7] px-[34px] py-[30px]">

--- a/src/components/common/userChat.tsx
+++ b/src/components/common/userChat.tsx
@@ -6,13 +6,14 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@/components/ui/sheet';
-import { PostContentProps } from '@/types/PostContent';
+import { DetailPost } from '@/types/DetailPost';
 import { Calendar, MoreHorizontal, Star, X } from 'lucide-react';
 
 import ChatList from './ChatList';
 import ChatNotice from './ChatNotice';
 
-interface UserChatProps extends PostContentProps {
+interface UserChatProps {
+    post: DetailPost;
     onClose?: () => void;
     onParticipate?: () => void;
 }
@@ -45,7 +46,7 @@ export default function UserChat({
 
                         {/* 유저 평점 */}
                         <span className="text-xs font-medium">
-                            {post.rating}
+                            {post.userRating}
                         </span>
                     </div>
                 </div>
@@ -68,7 +69,7 @@ export default function UserChat({
                         <div className="flex items-center gap-[3px]">
                             <Calendar className="h-4 w-4 text-[#666666]" />
                             <SheetDescription className="m-0 text-sm font-normal whitespace-nowrap text-[#666666]">
-                                {`${post.startDate} - ${post.endDate}`}
+                                {`${post.filter.startDate} - ${post.filter.endDate}`}
                             </SheetDescription>
                         </div>
                     </div>

--- a/src/components/common/userChat.tsx
+++ b/src/components/common/userChat.tsx
@@ -6,20 +6,27 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@/components/ui/sheet';
-import { DetailPost } from '@/types/DetailPost';
 import { Calendar, MoreHorizontal, Star, X } from 'lucide-react';
 
 import ChatList from './ChatList';
 import ChatNotice from './ChatNotice';
 
 interface UserChatProps {
-    post: DetailPost;
+    userName: string;
+    userRating: number;
+    title: string;
+    startDate: string;
+    endDate: string;
     onClose?: () => void;
     onParticipate?: () => void;
 }
 
 export default function UserChat({
-    post,
+    userName,
+    userRating,
+    title,
+    startDate,
+    endDate,
     onClose,
     onParticipate,
 }: UserChatProps) {
@@ -38,7 +45,7 @@ export default function UserChat({
                 <div className="inline-flex items-center gap-1">
                     {/* 유저 아이디 */}
                     <SheetTitle className="m-0 text-[15px] font-semibold text-black">
-                        {post.userName}
+                        {userName}
                     </SheetTitle>
 
                     <div className="inline-flex items-center gap-1 rounded-[50px] bg-[#ffd8001a] px-2 py-1 text-[#614e03]">
@@ -46,7 +53,7 @@ export default function UserChat({
 
                         {/* 유저 평점 */}
                         <span className="text-xs font-medium">
-                            {post.userRating}
+                            {userRating}
                         </span>
                     </div>
                 </div>
@@ -63,13 +70,11 @@ export default function UserChat({
             <section className="flex w-full flex-col gap-2.5 border-b px-5 py-4">
                 <div className="flex w-full items-center justify-between">
                     <div className="flex w-[365px] flex-col gap-[3px]">
-                        <h2 className="text-base font-semibold">
-                            {post.title}
-                        </h2>
+                        <h2 className="text-base font-semibold">{title}</h2>
                         <div className="flex items-center gap-[3px]">
                             <Calendar className="h-4 w-4 text-[#666666]" />
                             <SheetDescription className="m-0 text-sm font-normal whitespace-nowrap text-[#666666]">
-                                {`${post.filter.startDate} - ${post.filter.endDate}`}
+                                {`${startDate} - ${endDate}`}
                             </SheetDescription>
                         </div>
                     </div>

--- a/src/components/detail/RecruitFooter.tsx
+++ b/src/components/detail/RecruitFooter.tsx
@@ -4,11 +4,11 @@ import UserChat from '@/components/common/userChat';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent } from '@/components/ui/sheet';
-import { PostContentProps } from '@/types/PostContent';
+import { DetailPost } from '@/types/DetailPost';
 import Image from 'next/image';
 import { useState } from 'react';
 
-export default function RecruitFooter({ post }: PostContentProps) {
+export default function RecruitFooter({ post }: { post: DetailPost }) {
     const [showChat, setShowChat] = useState(false);
 
     const toggleChat = () => {
@@ -20,7 +20,10 @@ export default function RecruitFooter({ post }: PostContentProps) {
             <footer className="fixed right-0 bottom-0 left-0 z-40 w-full bg-white py-5 drop-shadow-2xl">
                 <div className="mx-auto flex max-w-[1240px] items-center justify-between px-4">
                     <div className="flex items-center gap-1.5">
-                        {new Date() < new Date(post.endDate) ? (
+                        {new Date() <
+                        new Date(
+                            `${post.filter.deadlineDate}T${post.filter.deadlineTime}`,
+                        ) ? (
                             <Badge>동행구함</Badge>
                         ) : (
                             <Badge variant={'disable'}>동행마감</Badge>

--- a/src/components/detail/RecruitFooter.tsx
+++ b/src/components/detail/RecruitFooter.tsx
@@ -52,7 +52,14 @@ export default function RecruitFooter({ post }: { post: DetailPost }) {
 
             <Sheet open={showChat} onOpenChange={setShowChat}>
                 <SheetContent side="right" className="p-0 sm:max-w-[580px]">
-                    <UserChat post={post} onClose={toggleChat} />
+                    <UserChat
+                        userName={post.userName}
+                        userRating={post.userRating}
+                        title={post.title}
+                        startDate={post.filter.startDate}
+                        endDate={post.filter.endDate}
+                        onClose={toggleChat}
+                    />
                 </SheetContent>
             </Sheet>
         </>

--- a/src/components/detail/RecruitFooter.tsx
+++ b/src/components/detail/RecruitFooter.tsx
@@ -20,13 +20,10 @@ export default function RecruitFooter({ post }: { post: DetailPost }) {
             <footer className="fixed right-0 bottom-0 left-0 z-40 w-full bg-white py-5 drop-shadow-2xl">
                 <div className="mx-auto flex max-w-[1240px] items-center justify-between px-4">
                     <div className="flex items-center gap-1.5">
-                        {new Date() <
-                        new Date(
-                            `${post.filter.deadlineDate}T${post.filter.deadlineTime}`,
-                        ) ? (
+                        {new Date() < new Date(post.filter.deadlineDate) ? (
                             <Badge>동행구함</Badge>
                         ) : (
-                            <Badge variant={'disable'}>동행마감</Badge>
+                            <Badge variant="disable">동행마감</Badge>
                         )}
                         <p className="text-base font-semibold text-black">
                             {post.title}

--- a/src/components/profile/MyGroupPost.tsx
+++ b/src/components/profile/MyGroupPost.tsx
@@ -14,6 +14,7 @@ interface MyGroupPostProps {
     posts: PostContentProps['post'][];
     cancelRecruit?: boolean;
 }
+
 // 게시글 삭제 여부 임시
 const isDeleted = false;
 
@@ -127,7 +128,11 @@ export default function MyGroupPost({
                                     className="p-0 sm:max-w-[580px]"
                                 >
                                     <UserChat
-                                        post={post}
+                                        userName={post.userName}
+                                        userRating={post.rating}
+                                        title={post.title}
+                                        startDate={post.startDate}
+                                        endDate={post.endDate}
                                         onClose={() => toggleChat(post.id)}
                                     />
                                 </SheetContent>

--- a/src/types/DetailPost.ts
+++ b/src/types/DetailPost.ts
@@ -1,3 +1,4 @@
+// api와 일치하는 타입 입니다.
 export interface DetailPost {
     id: number;
     title: string;
@@ -5,7 +6,6 @@ export interface DetailPost {
         startDate: string; // ISO 형식
         endDate: string;
         deadlineDate: string;
-        deadlineTime: string; // '18:00' 같은 문자열
         groupTheme: string;
         groupSize: string;
         gender: string;

--- a/src/types/HomePost.ts
+++ b/src/types/HomePost.ts
@@ -1,13 +1,13 @@
+//todo : gender쪽 필드명이 달라서 이후에 지울 타입 입니다.
 export interface HomePost {
     id: number;
     title: string;
     content: string;
     thumbnailUrl: string | null;
     filter: {
-        startDate: Date;
-        endDate: Date;
-        deadlineDate: Date;
-        deadlineTime: Date;
+        startDate: string;
+        endDate: string;
+        deadlineDate: string;
         groupTheme: string;
         groupSize: string;
         gender: string | null;


### PR DESCRIPTION
## 작업 내용 요약

-  모킹 데이터를 현재 날짜기준 +- 3일 로 생성하여 날짜 로직을 점검하였습니다.
-  date와 time을 하나의 Date로 합쳤습니다.  ( 글 작성이나 필터 부분은 건드리지 않았습니다. )

## 문제 상황

-  브라우저의 new Date () 는 유저기준 KST 이고 ec2 나 보편적 서버의 new Date ()  는 UDT 입니다.
-  시간과 날짜를 분리하면 날짜가 아무리 미래 이더라도, 시간에서 이상값이 생겨 과거로 인식되는 문제가 있습니다.
-  ex) 18:00 에 + 9 시간을 하면 27:00 이 되고 앞에 날짜와 더하면 날짜와 상관없이 동행 마감이 나오는 문제가 발생했습니다.

폼 작성시에도 마감 시간과 마감 날짜를 하나로 합치는게 좋을 것 같습니다. 

## 기타 공유 사항

- 하드코딩한 데이터와 포스트 데이터 타입 충돌이 생겨서 임시로 해결해 두었습니다.



