### PR TITLE
config: vercel 이미지 최적화 용량 초과로 최적화 비활성화

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,7 @@ const nextConfig: NextConfig = {
     compress: true, // 응답 압축으로 성능 향상
     poweredByHeader: false, // 보안을 위해 X-Powered-By 헤더 제거
     images: {
+        unoptimized: true,
         remotePatterns: [
             {
                 protocol: 'http',


### PR DESCRIPTION
### 내용

금일 QA 및 무한 스크롤 활성화 등 이유로 4900건 최적화 발생하여 Vercel 에서 402 에러를 반환 중 입니다.

next.config.ts 에서 *unpotimized: true* 적용 하였습니다.