### PR TITLE
feat: 프로필 이미지 업로드 기능 1차 구현 (보완 필요)

### DIFF
--- a/public/icon/profile/defaultProfile.svg
+++ b/public/icon/profile/defaultProfile.svg
@@ -1,11 +1,10 @@
-<svg width="96" height="104" viewBox="0 0 96 104" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g opacity="0.3">
-<mask id="mask0_1040_26277" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="96" height="96">
-<circle cx="48" cy="48" r="47.5" fill="white" stroke="black"/>
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1423_25249" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="96" height="96">
+<rect width="96" height="96" fill="#F5F6F7"/>
 </mask>
-<g mask="url(#mask0_1040_26277)">
-<circle cx="48" cy="33" r="17" fill="#999999"/>
-<path d="M91 97C91 120.748 71.7482 140 48 140C24.2518 140 5 120.748 5 97C5 73.2518 24.2518 54 48 54C71.7482 54 91 73.2518 91 97Z" fill="#999999"/>
-</g>
+<g mask="url(#mask0_1423_25249)">
+<rect width="96" height="96" fill="#F5F6F7"/>
+<circle cx="48" cy="32" r="17" fill="#D9DADB"/>
+<path d="M91 96C91 119.748 71.7482 139 48 139C24.2518 139 5 119.748 5 96C5 72.2518 24.2518 53 48 53C71.7482 53 91 72.2518 91 96Z" fill="#D9DADB"/>
 </g>
 </svg>


### PR DESCRIPTION
## 작업 내용 요약

- 프로필 편집 창에서 프로필 이미지를 업로드하는 기능을 1차로 구현했습니다. 


## 변경사항

- s3 프리사인 URL을 받은 후 버킷으로 직접 업로드하는 방식을 사용했습니다.

## 기타 참고사항

- 구성된 s3 api를 통해 프리사인 URL POST 요청은 로그 통해서 200 성공한 것 확인했습니다.
- 업로드한 이미지를 바로 불러와 유저 프로필 이미지로 적용하는 과정에서, 이미지가 제대로 받아지지 않고 있습니다.
- 이것 관련해서 이미지가 바로 받아지지는 않을거라고 중현 님께서 얼핏..? 말하셨던 것 같아서 일단 이렇게 두고 코어타임때 자세히 말씀드리겠습니다.

