### PR TITLE
feat: 댓글 답글 (Read, Create) 완료

### DIFF
--- a/src/components/Btn/AssignComment.tsx
+++ b/src/components/Btn/AssignComment.tsx
@@ -9,8 +9,9 @@ interface AssignCommentProps {
     content: string;
     parentId: number | null;
     postId: number;
-    setContent: React.Dispatch<React.SetStateAction<string>>;
     variant: 'Comment' | 'Reply';
+    setContent: React.Dispatch<React.SetStateAction<string>>;
+    setIsReplyInputOpen?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function AssignCommentBtn({
@@ -19,6 +20,7 @@ export default function AssignCommentBtn({
     postId,
     setContent,
     variant,
+    setIsReplyInputOpen,
 }: AssignCommentProps) {
     const router = useRouter();
     const [loading, setLoading] = useState(false);
@@ -58,8 +60,10 @@ export default function AssignCommentBtn({
         });
         setContent('');
         setLoading(false);
+        setIsReplyInputOpen?.(false);
         router.refresh();
     };
+
     return (
         <Button
             className="h-[37px] w-[92px] rounded-lg bg-[#999999] font-semibold text-white hover:bg-[#888888]"

--- a/src/components/comment/CommentBundle.tsx
+++ b/src/components/comment/CommentBundle.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import SingleComment from '@/components/comment/SingleComment';
+import PostInput from '@/components/detail/PostInput';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useState } from 'react';
 
@@ -32,6 +33,7 @@ export default function CommentBundle({
     postId: number;
 }) {
     const [isReplyOpen, setIsReplyOpen] = useState(false);
+    const [isReplyInputOpen, setIsReplyInputOpen] = useState(false);
 
     const replies = bundle.replies;
 
@@ -46,24 +48,36 @@ export default function CommentBundle({
                     writer: bundle.writer,
                     parentId: null,
                 }}
-                postId={postId}
                 variant="Parent"
+                setIsReplyInputOpen={setIsReplyInputOpen}
+                setIsReplyOpen={setIsReplyOpen}
             />
-
             {/* 답글 목록 */}
             {replies.length > 0 && (
                 <div>
                     <button
                         type={'button'}
-                        onClick={() => setIsReplyOpen((prev) => !prev)}
+                        onClick={() => {
+                            setIsReplyOpen((prev) => !prev);
+                            setIsReplyInputOpen((prev) => !prev);
+                        }}
+                        className="my-5 flex items-center"
                     >
                         <p className={'text-sky-blue text-xs font-medium'}>
                             답글 {replies.length}개
                         </p>
                         {isReplyOpen ? (
-                            <ChevronDown className={'h-[3.75px] w-[7.5px]'} />
+                            <ChevronDown
+                                size={10}
+                                strokeWidth={3}
+                                className="text-sky-blue ml-1.5 scale-x-[1.3]"
+                            />
                         ) : (
-                            <ChevronUp className={'h-[3.75px] w-[7.5px]'} />
+                            <ChevronUp
+                                size={10}
+                                strokeWidth={3}
+                                className="text-sky-blue ml-1.5 scale-x-[1.3]"
+                            />
                         )}
                     </button>
                     {isReplyOpen &&
@@ -78,12 +92,20 @@ export default function CommentBundle({
                                     parentId: reply.parentId || bundle.id,
                                 }}
                                 variant="Reply"
-                                postId={postId}
+                                setIsReplyInputOpen={setIsReplyInputOpen}
+                                setIsReplyOpen={setIsReplyOpen}
                             />
                         ))}
                 </div>
             )}
-
+            {isReplyInputOpen && (
+                <PostInput
+                    postId={postId}
+                    parentId={bundle.id}
+                    variant={'Reply'}
+                    setIsReplyInputOpen={setIsReplyInputOpen}
+                />
+            )}
             {/* 세퍼레이터 */}
             <div className="mt-5 h-px w-full bg-[#e9e9e9]" />
         </div>

--- a/src/components/comment/SingleComment.tsx
+++ b/src/components/comment/SingleComment.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import Replies from '@/components/Icons/Replies';
-import PostInput from '@/components/detail/PostInput';
 import { dateFormat } from '@/lib';
 import Image from 'next/image';
-import { useState } from 'react';
+import React from 'react';
 
 interface SingleCommentProps {
     content: {
@@ -18,7 +17,8 @@ interface SingleCommentProps {
         parentId: number | null;
     };
     variant: 'Parent' | 'Reply';
-    postId: number;
+    setIsReplyInputOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    setIsReplyOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 /**
@@ -31,15 +31,15 @@ interface SingleCommentProps {
 export default function SingleComment({
     content,
     variant,
-    postId,
+    setIsReplyInputOpen,
+    setIsReplyOpen,
 }: SingleCommentProps) {
-    const [isReplyInputOpen, setIsReplyInputOpen] = useState(false);
     return (
         <div>
             <div className="flex gap-2.5">
+                {variant === 'Reply' && <Replies className={'mt-2 shrink-0'} />}
+                {/*유저 정보 섹션*/}
                 <div>
-                    {variant === 'Reply' && <Replies className={'shrink-0'} />}
-                    {/*유저 정보 섹션*/}
                     <div className="flex flex-1 items-center gap-3">
                         {/*유저 이미지*/}
                         <div className="relative aspect-square h-8 w-8">
@@ -75,7 +75,8 @@ export default function SingleComment({
                                 className={`cursor-pointer text-xs font-medium text-[#666666]`}
                                 type="button"
                                 onClick={() => {
-                                    setIsReplyInputOpen((prev) => !prev);
+                                    setIsReplyOpen(true);
+                                    setIsReplyInputOpen(true);
                                 }}
                             >
                                 답글달기
@@ -84,13 +85,6 @@ export default function SingleComment({
                     </div>
                 </div>
             </div>
-            {isReplyInputOpen && (
-                <PostInput
-                    postId={postId}
-                    parentId={content.id}
-                    variant={'Reply'}
-                />
-            )}
         </div>
     );
 }

--- a/src/components/detail/PostInput.tsx
+++ b/src/components/detail/PostInput.tsx
@@ -4,7 +4,10 @@ import AssignComment from '@/components/Btn/AssignComment';
 import Replies from '@/components/Icons/Replies';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { useSession } from '@/hooks/useSession';
 import { cn } from '@/lib';
+import { useAppDispatch } from '@/redux/hooks';
+import { openLoginModal } from '@/redux/slices/modalSlice';
 import React, { useState } from 'react';
 
 /**
@@ -22,6 +25,8 @@ export default function PostInput({
     setIsReplyInputOpen?: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
     const [content, setContent] = useState('');
+    const dispatch = useAppDispatch();
+    const { isAuthenticated } = useSession();
     return (
         // 댓글 반복문에서 마진 40px + 10px =50px
         <div
@@ -41,12 +46,20 @@ export default function PostInput({
                         : 'min-h-[80px] text-base',
                 )}
                 placeholder={
-                    variant === 'Reply'
-                        ? '답글을 남겨 보세요'
-                        : '댓글을 남겨 주세요'
+                    isAuthenticated
+                        ? variant === 'Reply'
+                            ? '답글을 남겨 보세요'
+                            : '댓글을 남겨 주세요'
+                        : '로그인이 필요한 서비스 입니다.'
                 }
                 onChange={(e) => setContent(e.target.value)}
                 value={content}
+                onFocus={(e) => {
+                    if (!isAuthenticated) {
+                        e.target.blur();
+                        dispatch(openLoginModal());
+                    }
+                }}
             />
             {/*버튼 그룹*/}
             <section className={`flex justify-end gap-2`}>

--- a/src/components/detail/PostInput.tsx
+++ b/src/components/detail/PostInput.tsx
@@ -5,7 +5,7 @@ import Replies from '@/components/Icons/Replies';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib';
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 /**
  * 필드가 하나라 RHF 보다는 useState 로 입력값 관리 하였습니다.
@@ -14,10 +14,12 @@ export default function PostInput({
     parentId,
     postId,
     variant,
+    setIsReplyInputOpen,
 }: {
     parentId: number | null;
     postId: number;
     variant: 'Comment' | 'Reply';
+    setIsReplyInputOpen?: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
     const [content, setContent] = useState('');
     return (
@@ -26,7 +28,7 @@ export default function PostInput({
             className={cn(
                 `mt-2.5 flex w-auto flex-col gap-2 rounded-2xl border p-4`,
                 variant === 'Reply'
-                    ? 'ml-10 flex-row items-center border-[#dcdcdc] bg-[#fafafa]'
+                    ? 'ml-5 flex-row items-center border-[#dcdcdc] bg-[#fafafa]'
                     : 'bg-white',
             )}
         >
@@ -63,6 +65,7 @@ export default function PostInput({
                     postId={postId}
                     setContent={setContent}
                     variant={variant}
+                    setIsReplyInputOpen={setIsReplyInputOpen}
                 />
             </section>
         </div>


### PR DESCRIPTION
## 작업 내용 요약

- API 스펙에 맞춰 댓글, 답글 분기했습니다.
- 로그인 여부에 따라 placeholder, blur, modal 등 기능 추가했습니다.
- UI 피그마에 맞춰 수정했습니다. 

## 기타 참고사항

- 댓글 더보기 페이지네이션 기능은 아직 구현하지 못했습니다. 생각보다 댓글 답글 작성하는 부분 시간이 오래 걸린 것 같아요. 
- 리뷰의 경우 답글이 없어서 댓글보다 난이도가 쉬울 듯 합니다. 가능하면 오늘 내로 마무리 하겠습니다.

## 고민되는 부분

- 이후 더보기 기능 구현할 생각 입니다.  더보기 클릭 전에 데이터가 변경되면 정합성 이슈가 있을 것 같아서 해결책을 생각해 보겠습니다. ex) 1페이지와 2페이지 데이터 중복(신규 댓글/답글 추가) or 누락(삭제)
- 댓글이나 리뷰의 개수가 많지는 않을 것 같은데 전체 페이지를 끝까지 한번에 불러오고 숨겼다가 더보기로 펼치는 방식은 어떻게 생각하시나요?

## 스크린샷


https://github.com/user-attachments/assets/890fc6f2-4d1c-4be4-b2f8-fb65fdfbba7d


