### PR TITLE
feat: 댓글 페이징 구현 완료

### DIFF
--- a/src/app/[lang]/detail/[id]/page.tsx
+++ b/src/app/[lang]/detail/[id]/page.tsx
@@ -4,8 +4,8 @@ import TabSection from '@/components/detail/TabSection';
 import UserProfile from '@/components/detail/UserProfile';
 import {
     SpringCommentResponse,
-    fetchInitialComments,
-} from '@/lib/fetcher/fetchInitialComments';
+    fetchComments,
+} from '@/lib/fetcher/fetchComments';
 import { fetchPostDetail } from '@/lib/fetcher/fetchPostDetail';
 import { DetailPost } from '@/types/DetailPost';
 import Image from 'next/image';
@@ -25,7 +25,7 @@ export default async function DetailPage({ params }: DetailPageProps) {
     try {
         [post, firstCommentBundle] = await Promise.all([
             fetchPostDetail(id),
-            fetchInitialComments(Number(id)),
+            fetchComments(Number(id)),
         ]);
     } catch (error) {
         if ((error as Error).message === '404') {

--- a/src/components/comment/FetchMoreComments.tsx
+++ b/src/components/comment/FetchMoreComments.tsx
@@ -45,7 +45,7 @@ export default function FetchMoreComments({ postId }: { postId: number }) {
             {!isAllLoaded ? (
                 <button
                     onClick={handleLoadMore}
-                    className="my-12.5 flex h-12 w-full cursor-pointer items-center justify-center gap-2.5 rounded-lg bg-[#f5f6f7] px-5 py-0 text-[#666666]"
+                    className="mx-auto my-12.5 flex h-12 w-fit cursor-pointer items-center justify-center gap-2.5 rounded-lg bg-[#f5f6f7] px-5 py-0 text-[#666666]"
                 >
                     <p className="text-base leading-normal font-semibold whitespace-nowrap">
                         {isLoading ? (
@@ -59,7 +59,7 @@ export default function FetchMoreComments({ postId }: { postId: number }) {
             ) : (
                 <button
                     onClick={toggleFold}
-                    className="my-12.5 flex h-12 w-full cursor-pointer items-center justify-center gap-2.5 rounded-lg bg-[#f5f6f7] px-5 py-0 text-[#666666]"
+                    className="mx-auto my-12.5 flex h-12 w-fit cursor-pointer items-center justify-center gap-2.5 rounded-lg bg-[#f5f6f7] px-5 py-0 text-[#666666]"
                 >
                     <p className="text-base leading-normal font-semibold whitespace-nowrap">
                         {isFolded ? '댓글 펼치기' : '댓글 접기'}

--- a/src/components/comment/FetchMoreComments.tsx
+++ b/src/components/comment/FetchMoreComments.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+export default function FetchMoreComments() {
+    return (
+        <div>
+            <div></div>
+        </div>
+    );
+}

--- a/src/components/comment/FetchMoreComments.tsx
+++ b/src/components/comment/FetchMoreComments.tsx
@@ -1,9 +1,72 @@
 'use client';
 
-export default function FetchMoreComments() {
+import CommentBundle, { Comment } from '@/components/comment/CommentBundle';
+import { fetchComments } from '@/lib/fetcher/fetchComments';
+import { ChevronDown, ChevronUp, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+
+export default function FetchMoreComments({ postId }: { postId: number }) {
+    const [fetchedComments, setFetchedComments] = useState<Comment[]>([]);
+    const [page, setPage] = useState(1);
+    const [isFolded, setIsFolded] = useState(false);
+    const [isAllLoaded, setIsAllLoaded] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleLoadMore = async () => {
+        setIsLoading(true);
+        const result = await fetchComments(postId, page);
+        setFetchedComments((prev) => [...prev, ...result.content]);
+        setPage((prev) => prev + 1);
+        setIsLoading(false);
+        if (result.last) {
+            setIsAllLoaded(true);
+            setIsFolded(false);
+        }
+    };
+
+    const toggleFold = () => {
+        setIsFolded((prev) => !prev);
+    };
+
     return (
         <div>
-            <div></div>
+            {/* SSR 이후 댓글만 접기/펼치기 */}
+            {fetchedComments.length > 0 &&
+                !isFolded &&
+                fetchedComments.map((comment) => (
+                    <CommentBundle
+                        key={comment.id}
+                        bundle={comment}
+                        postId={postId}
+                    />
+                ))}
+
+            {/* 버튼 조건부 렌더링 */}
+            {!isAllLoaded ? (
+                <button
+                    onClick={handleLoadMore}
+                    className="my-12.5 flex h-12 w-full cursor-pointer items-center justify-center gap-2.5 rounded-lg bg-[#f5f6f7] px-5 py-0 text-[#666666]"
+                >
+                    <p className="text-base leading-normal font-semibold whitespace-nowrap">
+                        {isLoading ? (
+                            <Loader2 className="text-sky-blue animate-spin" />
+                        ) : (
+                            '댓글 더보기'
+                        )}
+                    </p>
+                    <ChevronDown />
+                </button>
+            ) : (
+                <button
+                    onClick={toggleFold}
+                    className="my-12.5 flex h-12 w-full cursor-pointer items-center justify-center gap-2.5 rounded-lg bg-[#f5f6f7] px-5 py-0 text-[#666666]"
+                >
+                    <p className="text-base leading-normal font-semibold whitespace-nowrap">
+                        {isFolded ? '댓글 펼치기' : '댓글 접기'}
+                    </p>
+                    {isFolded ? <ChevronDown /> : <ChevronUp />}
+                </button>
+            )}
         </div>
     );
 }

--- a/src/components/comment/PostComment.tsx
+++ b/src/components/comment/PostComment.tsx
@@ -1,4 +1,5 @@
 import CommentBundle from '@/components/comment/CommentBundle';
+import FetchMoreComments from '@/components/comment/FetchMoreComments';
 import PostInput from '@/components/detail/PostInput';
 import { SpringCommentResponse } from '@/lib/fetcher/fetchInitialComments';
 
@@ -44,6 +45,8 @@ export default function PostComment({
                     {/*글이 없는 경우 100% 신규 부모댓글 이므로 null , api 스펙이 null 명시되어 있습니다.*/}
                 </>
             )}
+            {/*SSR 결과가 마지막 페이지가 아니라면 실행*/}
+            {!firstCommentBundle.last && <FetchMoreComments />}
             <PostInput postId={postId} parentId={null} variant={'Comment'} />
         </div>
     );

--- a/src/components/comment/PostComment.tsx
+++ b/src/components/comment/PostComment.tsx
@@ -1,7 +1,7 @@
 import CommentBundle from '@/components/comment/CommentBundle';
 import FetchMoreComments from '@/components/comment/FetchMoreComments';
 import PostInput from '@/components/detail/PostInput';
-import { SpringCommentResponse } from '@/lib/fetcher/fetchInitialComments';
+import { SpringCommentResponse } from '@/lib/fetcher/fetchComments';
 
 /**
  * 첫 페이지는 서버사이드 랜더링으로 불러와서 내려줍니다.
@@ -46,7 +46,7 @@ export default function PostComment({
                 </>
             )}
             {/*SSR 결과가 마지막 페이지가 아니라면 실행*/}
-            {!firstCommentBundle.last && <FetchMoreComments />}
+            {!firstCommentBundle.last && <FetchMoreComments postId={postId} />}
             <PostInput postId={postId} parentId={null} variant={'Comment'} />
         </div>
     );

--- a/src/components/detail/TabSection.tsx
+++ b/src/components/detail/TabSection.tsx
@@ -5,7 +5,7 @@ import PostContent from '@/components/detail/PostContent';
 import PostLocation from '@/components/detail/PostLocation';
 import PostReview from '@/components/detail/PostReview';
 import ScrollSpy from '@/components/detail/ScrollSpy';
-import { SpringCommentResponse } from '@/lib/fetcher/fetchInitialComments';
+import { SpringCommentResponse } from '@/lib/fetcher/fetchComments';
 import { DetailPost } from '@/types/DetailPost';
 import { useRef } from 'react';
 

--- a/src/lib/fetcher/fetchComments.ts
+++ b/src/lib/fetcher/fetchComments.ts
@@ -14,12 +14,14 @@ export type SpringCommentResponse = {
  * <server only>
  * 게시글 기준 초기 댓글 SSR 하는 유틸함수
  * @param postId
+ * @param page
  */
-export async function fetchInitialComments(
+export async function fetchComments(
     postId: number,
+    page: number = 0,
 ): Promise<SpringCommentResponse> {
     const res = await fetch(
-        `${process.env.NEXT_PUBLIC_NEST_BFF_URL}/api/gatherings/${postId}/comments?page=0&size=7`,
+        `${process.env.NEXT_PUBLIC_NEST_BFF_URL}/api/gatherings/${postId}/comments?page=${page}&size=5`,
         {
             method: 'GET',
             credentials: 'include',


### PR DESCRIPTION
## 작업 내용 요약

- 최초 SSR 데이터는 유지해두고, 더보기 버튼 클릭시 5 개씩 댓글을 불러오도록 수정했습니다.
- 마지막 페이지에 도달하면 접기 버튼으로 바뀌고, 접을 경우 데이터는 유지하고, 다시 전체 댓글을 펼칠 수 있게 했습니다. ( 사용자가 또 페이지네이션 수행하는 것을 방지 )

## 기타 참고사항

- 댓글 작성시에 router.refresh() 가 있어서 리액트 쿼리는 사용하지 않았습니다. ( 캐싱 의미가 없다고 판단했습니다. )

## 스크린샷



https://github.com/user-attachments/assets/861527d5-c5ec-436b-841d-f5e59fdc4c36




