### PR TITLE
feat: 프로필 유저 레이팅, 평점 반영

### DIFF
--- a/src/app/api/filter/route.ts
+++ b/src/app/api/filter/route.ts
@@ -11,9 +11,7 @@ export async function GET(request: Request) {
     console.log(filters);
 
     const response = await fetch(
-
-        `${process.env.NEXT_PUBLIC_NEST_BFF_URL}/api/filter?filters=${filters}`,
-
+        `${process.env.NEXT_PUBLIC_NEST_BFF_URL}/api/gatherings/filter?filters=${filters}`,
     );
     const data = await response.json();
 

--- a/src/components/profile/MypageProfile.tsx
+++ b/src/components/profile/MypageProfile.tsx
@@ -14,6 +14,8 @@ interface User {
     thumbnailUrl?: string;
     ageGroup?: string;
     gender?: string;
+    averageRating?: number;
+    totalReviews: number;
 }
 
 interface MypageProfileProps {
@@ -50,6 +52,8 @@ export default function MypageProfile({ data, isVisitor }: MypageProfileProps) {
             data.gender &&
             genderDisplay[data.gender as keyof typeof genderDisplay],
         profileImage: data.thumbnailUrl,
+        averageRating: data.averageRating,
+        totalReviews: data.totalReviews,
     };
     const isProfileFilled: boolean = checkProfileComplete(profileData);
 
@@ -160,9 +164,10 @@ export default function MypageProfile({ data, isVisitor }: MypageProfileProps) {
                         <StarIcon className="h-8 w-8 fill-current text-[#FFD700]" />
                         <span className="text-right text-[28px] font-semibold text-[#333333]">
                             {/*todo: 평점과 리뷰 관련 정보는 아직 api에서 조회 불가한 것 같습니다.*/}
-                            {/*{profileData.rating.toFixed(1)}(*/}
-                            {/*{profileData.reviews})*/}
-                            4.5(1)
+                            {profileData.averageRating
+                                ? profileData.averageRating.toFixed(1)
+                                : 0}
+                            ({profileData.totalReviews})
                         </span>
                     </div>
                 </div>

--- a/src/components/profile/MypageProfile.tsx
+++ b/src/components/profile/MypageProfile.tsx
@@ -163,7 +163,6 @@ export default function MypageProfile({ data, isVisitor }: MypageProfileProps) {
                     <div className="flex w-full items-center justify-end gap-1">
                         <StarIcon className="h-8 w-8 fill-current text-[#FFD700]" />
                         <span className="text-right text-[28px] font-semibold text-[#333333]">
-                            {/*todo: 평점과 리뷰 관련 정보는 아직 api에서 조회 불가한 것 같습니다.*/}
                             {profileData.averageRating
                                 ? profileData.averageRating.toFixed(1)
                                 : 0}


### PR DESCRIPTION
### 변경 사항

- 소감 (Review) 에서 마이페이지의 프로필에 rating 표시 api 필드 추가 요청드렸고, 연결 완료 되었습니다.

### 참고 사항

- 남에게 보여지는 프로필 페이지의 경우에 api 수정이 필요해서 요청드린 상황 입니다.
- detail 페이지의 주최자 평점 필드도 추가 요청 드렸고, 저녁쯤 수정 가능하다고 하셔서 반영 예정입니다. 

### TODO : 검색, 필터링쪽 연결하면 Api 연결 작업은 끝날 것 같습니다. 