### PR TITLE
design: 상세페이지 참여 인원보기 추가

### DIFF
--- a/src/components/common/RecruitPost.tsx
+++ b/src/components/common/RecruitPost.tsx
@@ -57,7 +57,7 @@ export default function RecruitPost({ post }: PostContentProps) {
                             </Badge>
 
                             {/* 글제목  */}
-                            <h1 className="flex-1 truncate overflow-hidden text-xl font-bold text-black">
+                            <h1 className="max-w-[320px] flex-1 truncate overflow-hidden text-xl font-bold text-black">
                                 {post.title}
                             </h1>
                         </div>

--- a/src/components/detail/MemberSection.tsx
+++ b/src/components/detail/MemberSection.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import UserProfile from '@/components/detail/UserProfile';
+import { useEffect, useState } from 'react';
+
+import LoadingThreeDots from '../common/LoadingThreeDots';
+
+// 참여자 정보 인터페이스 정의
+interface GatheringMemberResponseDto {
+    userId: number;
+    user: UserProfileDto;
+    status: 'APPLYING' | 'BLOCKED' | 'ACCEPTED';
+}
+interface UserProfileDto {
+    kakaoId: number;
+    nickname: string;
+    thumbnailUrl: string;
+    statusMessage: string;
+    gender: 'MALE' | 'FEMALE' | 'ANY';
+    ageGroup:
+        | 'ALL'
+        | 'TEENS'
+        | 'TWENTIES'
+        | 'THIRTIES'
+        | 'FORTIES'
+        | 'FIFTIES'
+        | 'SIXTIES'
+        | 'SEVENTIES';
+}
+interface MemberSectionProps {
+    gatheringId: number;
+}
+
+export default function MemberSection({ gatheringId }: MemberSectionProps) {
+    // 참여자 목록 상태 관리
+    const [participants, setParticipants] = useState<
+        GatheringMemberResponseDto[]
+    >([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    // 참여자 목록 조회 api
+    useEffect(() => {
+        const fetchParticipants = async () => {
+            try {
+                setIsLoading(true);
+                const NEXT_PUBLIC_NEST_BFF_URL =
+                    process.env.NEXT_PUBLIC_NEST_BFF_URL ||
+                    'http://localhost:3000';
+                const response = await fetch(
+                    `${NEXT_PUBLIC_NEST_BFF_URL}/api/gatherings/participants/${gatheringId}`,
+                    {
+                        credentials: 'include',
+                    },
+                );
+
+                if (!response.ok) {
+                    throw new Error(
+                        `참여자 목록을 불러오는데 실패했습니다: ${response.status}`,
+                    );
+                }
+
+                const data = await response.json();
+                setParticipants(data);
+            } catch (err) {
+                console.error('참여자 목록 조회 오류:', err);
+                setError(
+                    err instanceof Error ? err.message : '알 수 없는 오류',
+                );
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        fetchParticipants();
+    }, [gatheringId]);
+
+    // 연령 스키마를 ui로 변경
+    const convertAgeGroupToNumber = (ageGroup: string): number | string => {
+        switch (ageGroup) {
+            case 'TEENS':
+                return '10대';
+            case 'TWENTIES':
+                return '20대';
+            case 'THIRTIES':
+                return '30대';
+            case 'FORTIES':
+                return '40대';
+            case 'FIFTIES':
+                return '50대';
+            case 'SIXTIES':
+                return '60대';
+            case 'SEVENTIES':
+                return '70대';
+            case 'ALL':
+            default:
+                return 0;
+        }
+    };
+
+    // 성별 스키마를 ui로 변경
+    const convertGenderToKorean = (gender: string): string => {
+        switch (gender) {
+            case 'MALE':
+                return '남성';
+            case 'FEMALE':
+                return '여성';
+            case 'ANY':
+            default:
+                return '무관';
+        }
+    };
+
+    return (
+        <div className="mt-12.5">
+            <h2 className="mb-5 text-xl font-bold">멤버 소개</h2>
+            {isLoading ? (
+                <div className="flex h-40 items-center justify-center">
+                    <LoadingThreeDots />
+                </div>
+            ) : error ? (
+                <div className="flex h-40 items-center justify-center text-red-500">
+                    <p>{error}</p>
+                </div>
+            ) : participants.length === 0 ? (
+                <div className="flex h-40 items-center justify-center">
+                    <p>아직 참여자가 없습니다.</p>
+                </div>
+            ) : (
+                <div className="space-y-6">
+                    {/* 모든 멤버 보기 갯수 제한  */}
+                    {participants.slice(0, 5).map((participant) => (
+                        <UserProfile
+                            key={participant.userId}
+                            post={{
+                                userName: participant.user.nickname,
+                                statusMessage: participant.user.statusMessage,
+                                userAge: convertAgeGroupToNumber(
+                                    participant.user.ageGroup,
+                                ),
+                                userGender: convertGenderToKorean(
+                                    participant.user.gender,
+                                ),
+                                userRating: 0, // API에서 제공하지 않아 임시 값 지정
+                                profileImage: participant.user.thumbnailUrl,
+                                kakaoId: participant.user.kakaoId,
+                            }}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/detail/TabSection.tsx
+++ b/src/components/detail/TabSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import PostComment from '@/components/comment/PostComment';
+import MemberSection from '@/components/detail/MemberSection';
 import PostContent from '@/components/detail/PostContent';
 import PostLocation from '@/components/detail/PostLocation';
 import PostReview from '@/components/detail/PostReview';
@@ -54,13 +55,9 @@ export default function TabSection({
                     lng={post.location.longitude}
                 />
             </section>
-            {/*todo: 멤버 소개 섹션*/}
+            {/*멤버 소개 섹션*/}
             <section ref={memberAreaRef} className="scroll-mt-40">
-                <div
-                    className={`bg-sky-blue mt-12.5 flex h-40 items-center justify-center text-2xl font-black text-white`}
-                >
-                    <p> 멤버 소개 섹션 준비중 입니다.</p>
-                </div>
+                <MemberSection gatheringId={post.id} />
             </section>
             {/*댓글 섹션*/}
             <section ref={commentAreaRef} className={`mt-15 scroll-mt-40`}>

--- a/src/components/detail/UserProfile.tsx
+++ b/src/components/detail/UserProfile.tsx
@@ -5,7 +5,7 @@ interface UserProfileProps {
     post: {
         userName: string;
         statusMessage: string;
-        userAge: number;
+        userAge: number | string;
         userGender: string;
         userRating: number;
         profileImage: string;
@@ -37,12 +37,12 @@ export default function UserProfile({ post }: UserProfileProps) {
                         />
                     </div>
                     {/* 유저 정보 */}
-                    <div className="flex w-[187px] flex-col items-start gap-1.5">
-                        <h1 className="w-full text-[15px] font-semibold text-black">
+                    <div className="flex max-w-[300px] min-w-[187px] flex-col items-start gap-1.5">
+                        <h1 className="w-full truncate text-[15px] font-semibold text-black">
                             {post.userName}
                         </h1>
                         <div className="flex items-center gap-2 rounded-[24.53px] bg-[#e5e8ea] px-3 py-1.5">
-                            <p className="text-xs text-[#666666]">
+                            <p className="max-w-[140px] truncate text-xs text-[#666666]">
                                 {post.statusMessage}
                             </p>
                             <div className="h-1.5 w-px bg-gray-300" />
@@ -67,9 +67,12 @@ export default function UserProfile({ post }: UserProfileProps) {
                             width={16}
                             height={16}
                         />
+
                         <p className="text-base font-semibold">
-                            {/*todo:레이팅총개수 */}
-                            {`${post.userRating.toFixed(1)}(10)`}
+                            {/* 0점이면 0.0으로 표기하지 않음 */}
+                            {post.userRating === 0
+                                ? `0(10)`
+                                : `${post.userRating.toFixed(1)}(10)`}
                         </p>
                     </div>
 


### PR DESCRIPTION
## 작업 내용 요약

- 상세페이지에서 현재 참여가 확정된 인원(작성자 포함)을 보여주는 기능을 추가했습니다.
- 참여 확정 인원을 불러오는 api에는 페이지네이션이 없어 일단 5개까지만 보이도록 반복문에 slice로 제한을 두었습니다.
- 항상 소수 첫 번째 자리까지 보이도록 했는데, 0점일때는 0.0이 좀 이상해서 0.0일때만 0으로 표기하게 했습니다.
- 상태메세지가 너무 길면 `...`으로 표기되도록 제한하였습니다.
 
<img width="1013" alt="스크린샷 2025-04-14 오후 3 06 43" src="https://github.com/user-attachments/assets/f870fa8b-68b2-4460-90ec-dd1838db9561" />
