### PR TITLE
feat: 필터링 기능 추가, 로고쪽 검색 기능과 컨플릭 해결, 채팅 메세지 시간 표시

### DIFF
--- a/src/api/gatheringApi.ts
+++ b/src/api/gatheringApi.ts
@@ -1,0 +1,122 @@
+import { BEHomePost } from '@/types/BEHomePost';
+
+const paramMappings: Record<string, string> = {
+    category: 'category',
+    preferredGender: 'preferredGender',
+    preferredAge: 'preferredAge',
+    address: 'address',
+    startDate: 'startDate',
+    endDate: 'endDate',
+    maxParticipants: 'maxParticipants',
+};
+
+/**
+디버 * 백엔드 API 응답 타입 정의
+ */
+export interface GatheringResponse {
+    content: Array<BEHomePost>;
+    number: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+    last: boolean;
+    first: boolean;
+    empty: boolean;
+}
+
+/**
+ * 게시물 목록을 가져오는 API 함수
+ */
+export const fetchGatherings = async (
+    searchParams: URLSearchParams,
+    pageParam: number = 1,
+): Promise<GatheringResponse> => {
+    const NEXT_PUBLIC_NEST_BFF_URL = process.env.NEXT_PUBLIC_NEST_BFF_URL;
+
+    // 필터 파라미터가 있는지 확인 (더 간결한 방식으로 변경)
+    const hasFilters = hasActiveFilters(searchParams);
+
+    let url;
+    if (hasFilters) {
+        // 백엔드 API 요청을 위한 URL 구성
+        const apiParams = new URLSearchParams();
+
+        // 필터 파라미터 추가 (페이지네이션 제외)
+        for (const [key, value] of searchParams.entries()) {
+            // 유효한 파라미터만 처리
+            if (
+                value &&
+                value !== 'undefined' &&
+                value !== 'null' &&
+                !['page', 'size'].includes(key) &&
+                paramMappings[key]
+            ) {
+                // 날짜 형식 변환 YYYY-MM-EE
+                if (['startDate', 'endDate'].includes(key)) {
+                    const formattedDate = new Date(value)
+                        .toISOString()
+                        .split('T')[0];
+                    apiParams.set(paramMappings[key], formattedDate);
+                }
+                // 숫자 변환
+                else if (key === 'maxParticipants') {
+                    apiParams.set(paramMappings[key], String(parseInt(value)));
+                }
+                // 일반 문자열
+                else {
+                    apiParams.set(paramMappings[key], value);
+                }
+            }
+        }
+
+        // 페이지네이션 파라미터 추가
+        apiParams.set('page', String(pageParam - 1)); // 1-based를 0-based로 변환
+        apiParams.set('size', '10');
+
+        url = `${NEXT_PUBLIC_NEST_BFF_URL}/api/gatherings/filter?${apiParams.toString()}`;
+    } else {
+        url = `${NEXT_PUBLIC_NEST_BFF_URL}/api/gatherings/list?page=${pageParam - 1}&size=10`; // 1-based to 0-based
+    }
+
+    // API request and response handling
+    try {
+        console.log(`Requesting URL for page ${pageParam}: ${url}`);
+        const response = await fetch(url);
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(
+                `HTTP error! status: ${response.status}, message: ${errorText}`,
+            );
+        }
+
+        const data = await response.json();
+        console.log(`API Response for page ${pageParam}:`, {
+            number: data.number,
+            size: data.size,
+            totalElements: data.totalElements,
+            totalPages: data.totalPages,
+            last: data.last,
+            contentLength: data.content?.length,
+            hasContent: !!data.content,
+            firstItemId: data.content?.[0]?.id || 'N/A',
+        });
+        return data;
+    } catch (error) {
+        console.error('API request failed:', error);
+        throw error;
+    }
+};
+
+/**
+ * 필터링이 적용되었는지 확인하는 함수
+ */
+export const hasActiveFilters = (searchParams: URLSearchParams): boolean => {
+    return Array.from(searchParams.entries()).some(
+        ([key, value]) =>
+            !['page', 'size'].includes(key) &&
+            value &&
+            value !== 'undefined' &&
+            value !== 'null',
+    );
+};

--- a/src/app/[lang]/chat/[kakaoId]/page.tsx
+++ b/src/app/[lang]/chat/[kakaoId]/page.tsx
@@ -15,6 +15,7 @@ interface ChatRoom {
     lastMessage: string;
     unreadCount: number;
     thumbnailUrl?: string;
+    sentAt: string; // Add this field
 }
 
 // 채팅 상대 프로필 표시를 위한 호출
@@ -149,8 +150,8 @@ export default function Chat() {
                                                     chatData.lastMessage,
                                                 unreadChat:
                                                     chatData.unreadCount,
-
-                                                // 원래는 Location이나, 현재 프로필에 지역정보가 없어서 일단 상태메세지로 대체합니다.
+                                                sentAt: chatData.sentAt, // Add this field
+                                                // 원래는 Location이나, 현재 프로필에 지역정보가 없습니다.
                                                 statusMessage:
                                                     userProfiles[
                                                         chatData.opponentKakaoId

--- a/src/app/[lang]/liked/page.tsx
+++ b/src/app/[lang]/liked/page.tsx
@@ -27,7 +27,14 @@ export default function LikedPage() {
                     credentials: 'include',
                 });
                 const data = await response.json();
-                setFormattedPosts(Array.isArray(data) ? data : []);
+                // 중복으로 생성되는 버그 수정
+                const uniquePosts = Array.isArray(data)
+                    ? data.filter(
+                          (post, index, self) =>
+                              index === self.findIndex((p) => p.id === post.id),
+                      )
+                    : [];
+                setFormattedPosts(uniquePosts);
             } catch (error) {
                 console.error('Failed to fetch liked posts:', error);
                 setFormattedPosts([]);

--- a/src/components/Editor/PostSetupPanel.tsx
+++ b/src/components/Editor/PostSetupPanel.tsx
@@ -266,9 +266,9 @@ export default function PostSetupPanel() {
                             <SelectValue placeholder="동행 테마 선택" />
                         </SelectTrigger>
                         <SelectContent>
-                            <SelectItem value="friends">친구 동반</SelectItem>
-                            <SelectItem value="couple">부부 동반</SelectItem>
-                            <SelectItem value="tour">투어 동반</SelectItem>
+                            <SelectItem value="friends">친구 동행</SelectItem>
+                            <SelectItem value="part">부분 동행</SelectItem>
+                            <SelectItem value="tour">투어 동행</SelectItem>
                             <SelectItem value="booking">숙박 공유</SelectItem>
                             <SelectItem value="event">
                                 전시/공연 동행

--- a/src/components/chat/ChatPreview.tsx
+++ b/src/components/chat/ChatPreview.tsx
@@ -6,12 +6,41 @@ interface ChatProps {
         name: string;
         lastMessage: string;
         unreadChat: number;
-        statusMessage?: string; // 원래는 Location이나, statusMessage로 대체
+        statusMessage?: string;
         thumbnailUrl: string;
+        sentAt: string; // Add sentAt to the interface
     };
 }
 
 export default function ChatPreview({ chatData }: ChatProps) {
+    const formatTime = (dateString: string) => {
+        const now = new Date();
+        const date = new Date(dateString);
+        const diffMs = now.getTime() - date.getTime();
+        const diffMinutes = Math.floor(diffMs / (1000 * 60));
+        const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+        const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+        // 1시간 전 표기 방식
+        if (diffHours < 1) {
+            return `${diffMinutes}분 전`;
+        }
+        // 1시간을 넘어가면 시간 단위로 표기
+        else if (diffDays < 1) {
+            return `${diffHours}시간 전`;
+        }
+        // 메세지를 받은지 하루가 지나면 날짜를 표기함: YY.MM.DD형식
+        else {
+            return date
+                .toLocaleDateString('ko-KR', {
+                    year: '2-digit',
+                    month: '2-digit',
+                    day: '2-digit',
+                })
+                .replace(/\. /g, '.')
+                .slice(0, -1);
+        }
+    };
+
     return (
         <article className="flex h-[60px] w-full cursor-pointer items-center px-2">
             <div className="mr-3.5 h-[60px] w-[60px] flex-shrink-0 overflow-hidden rounded-full bg-gray-200">
@@ -25,19 +54,20 @@ export default function ChatPreview({ chatData }: ChatProps) {
             </div>
 
             <div className="flex min-w-0 flex-1 flex-col justify-center gap-[7px]">
-                <div className="flex items-center">
-                    {/* 유저이름 */}
-                    <div className="text-base font-semibold">
-                        {chatData.name}
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center">
+                        <div className="text-base font-semibold">
+                            {chatData.name}
+                        </div>
+                        <div className="mx-[6px] text-base font-semibold text-[#333333]">
+                            ·
+                        </div>
+                        <div className="text-xs font-medium text-[#666666]">
+                            {chatData.statusMessage || '상태 메시지가 없습니다'}
+                        </div>
                     </div>
-
-                    {/* 유저 상태 메세지 -> 피그마대로면 원래 상대의 선호 지역 정보이나, 저희 프로필 설정에는 지역 정보가 없습니다. */}
-                    <div className="mx-[6px] text-base font-semibold text-[#333333]">
-                        ·
-                    </div>
-                    <div className="text-xs font-medium text-[#666666]">
-                        {/* TODO 추후 지역 정보로 변경 */}
-                        {chatData.statusMessage || '상태 메시지가 없습니다'}
+                    <div className="text-xs text-gray-500">
+                        {chatData.sentAt && formatTime(chatData.sentAt)}
                     </div>
                 </div>
                 <p className="max-w-[360px] truncate text-sm text-gray-600">

--- a/src/components/home/InfiniteScroll.tsx
+++ b/src/components/home/InfiniteScroll.tsx
@@ -14,12 +14,25 @@ import CreatePostWindow from './CreatePostWindow';
 
 interface InfiniteScrollProps {
     initialPosts: BEHomePost[];
+    keyword?: string;
 }
 
-export default function InfiniteScroll({ initialPosts }: InfiniteScrollProps) {
+/**
+ * 0 페이지 데이터는 SSR 로 넘겨받아서 랜더링
+ * 이후 페이지에 대해 무한스크롤 (page=1, default size = 10 입니다.)
+ * @param initialPosts
+ * @param queryKey
+ * @param fetchFn
+ * @constructor
+ */
+export default function InfiniteScroll({
+    initialPosts,
+    keyword,
+}: InfiniteScrollProps) {
     const ref = useRef(null);
     const isInView = useInView(ref);
     const searchParams = useSearchParams();
+    const NEXT_PUBLIC_NEST_BFF_URL = process.env.NEXT_PUBLIC_NEST_BFF_URL;
 
     const {
         data,
@@ -30,34 +43,61 @@ export default function InfiniteScroll({ initialPosts }: InfiniteScrollProps) {
         isError,
         refetch,
     } = useInfiniteQuery({
-        queryKey: ['posts', searchParams.toString()],
+        queryKey: keyword
+            ? ['search', keyword]
+            : ['posts', searchParams.toString()],
         queryFn: async ({ pageParam = 1 }) => {
             try {
-                return await fetchGatherings(
-                    new URLSearchParams(searchParams.toString()),
-                    pageParam,
-                );
+                if (keyword) {
+                    const baseURL = `${NEXT_PUBLIC_NEST_BFF_URL}/api/gatherings/list`;
+                    const query = `page=${pageParam - 1}&size=10`;
+                    const keywordQuery = `&keyword=${encodeURIComponent(keyword)}`;
+                    const res = await fetch(
+                        `${baseURL}?${query}${keywordQuery}`,
+                        {
+                            cache: 'no-store',
+                        },
+                    );
+                    return res.json();
+                } else {
+                    console.log('Fetching page:', pageParam);
+                    return await fetchGatherings(
+                        new URLSearchParams(searchParams.toString()),
+                        pageParam,
+                    );
+                }
             } catch (error) {
                 console.error('Fetch error:', error);
                 throw error;
             }
         },
         getNextPageParam: (lastPage) => {
-            if (lastPage.last) return undefined;
-            return lastPage.number + 2;
+            // 마지막 페이지인 경우 undefined 반환
+            if (lastPage.last) {
+                console.log('No more pages to fetch');
+                return undefined;
+            }
+
+            // 다음 페이지 번호 계산 (백엔드는 0-based, 프론트엔드는 1-based)
+            return lastPage.number + 2; // 0-based에서 1-based로 변환 후 다음 페이지
         },
         initialPageParam: 1,
     });
 
     useEffect(() => {
-        const timeoutId = setTimeout(() => {
+        const handleFetchNext = async () => {
             if (isInView && !isFetchingNextPage && hasNextPage) {
-                fetchNextPage({ cancelRefetch: false });
+                console.log('Fetching next page...');
+                await fetchNextPage({ cancelRefetch: false });
             }
-        }, 300);
+        };
+
+        // 디바운싱 처리를 통한 데이터 두 번 로드되는 버그 수정
+        const timeoutId = setTimeout(handleFetchNext, 300); // 100ms에서 300ms로 증가
         return () => clearTimeout(timeoutId);
     }, [isInView, fetchNextPage, isFetchingNextPage, hasNextPage]);
 
+    // 검색 파라미터가 변경될 때마다 데이터 다시 가져오기
     useEffect(() => {
         refetch();
     }, [searchParams, refetch]);
@@ -67,6 +107,7 @@ export default function InfiniteScroll({ initialPosts }: InfiniteScrollProps) {
         return <CreatePost />;
     }
 
+    // 필터링 상태 및 데이터 확인
     const activeFilters = hasActiveFilters(
         new URLSearchParams(searchParams.toString()),
     );
@@ -74,6 +115,7 @@ export default function InfiniteScroll({ initialPosts }: InfiniteScrollProps) {
 
     return (
         <div className="mt-6 grid max-w-[1200px] grid-cols-1 gap-6 lg:grid-cols-2">
+            {/* SSR로 받은 초기 데이터는 필터링이 없을 때만 렌더링 */}
             {!activeFilters &&
                 !data?.pages?.length &&
                 initialPosts?.map((post) => (
@@ -87,6 +129,7 @@ export default function InfiniteScroll({ initialPosts }: InfiniteScrollProps) {
                     </motion.div>
                 ))}
 
+            {/* 클라이언트에서 가져온 데이터 */}
             {data?.pages?.map((page, pageIndex) =>
                 (page?.content || []).map(
                     (post: BEHomePost, postIndex: number) => (
@@ -105,13 +148,18 @@ export default function InfiniteScroll({ initialPosts }: InfiniteScrollProps) {
                 ),
             )}
 
+            {/* 글이 없는 경우 띄울 Ui */}
             {hasNoData && <CreatePost />}
+
+            {/* 첫 로딩을 끝낸 이후 데이터가 있으면 게시글 작성 버튼을 fixed로 띄웁니다. */}
             {!isLoading && !hasNoData && <CreatePostWindow />}
+
             {isFetchingNextPage && (
                 <div className="col-span-full py-8">
                     <LoadingThreeDots />
                 </div>
             )}
+
             <div className="col-span-full h-1 w-full" ref={ref}></div>
         </div>
     );

--- a/src/components/home/InfiniteScroll.tsx
+++ b/src/components/home/InfiniteScroll.tsx
@@ -1,36 +1,25 @@
 'use client';
 
+import { fetchGatherings, hasActiveFilters } from '@/api/gatheringApi';
 import RecruitPost from '@/components/common/RecruitPost';
 import { BEHomePost } from '@/types/BEHomePost';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { motion, useInView } from 'motion/react';
+import { useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 
-// api 생기면 삭제
 import LoadingThreeDots from '../common/LoadingThreeDots';
 import CreatePost from './CreatePost';
 import CreatePostWindow from './CreatePostWindow';
 
 interface InfiniteScrollProps {
     initialPosts: BEHomePost[];
-    keyword?: string;
 }
 
-/**
- * 0 페이지 데이터는 SSR 로 넘겨받아서 랜더링
- * 이후 페이지에 대해 무한스크롤 (page=1, default size = 10 입니다.)
- * @param initialPosts
- * @param queryKey
- * @param fetchFn
- * @constructor
- */
-export default function InfiniteScroll({
-    initialPosts,
-    keyword,
-}: InfiniteScrollProps) {
+export default function InfiniteScroll({ initialPosts }: InfiniteScrollProps) {
     const ref = useRef(null);
     const isInView = useInView(ref);
-    const NEXT_PUBLIC_NEST_BFF_URL = process.env.NEXT_PUBLIC_NEST_BFF_URL;
+    const searchParams = useSearchParams();
 
     const {
         data,
@@ -39,89 +28,90 @@ export default function InfiniteScroll({
         isFetchingNextPage,
         isLoading,
         isError,
+        refetch,
     } = useInfiniteQuery({
-        queryKey: keyword ? ['search', keyword] : ['posts'],
+        queryKey: ['posts', searchParams.toString()],
         queryFn: async ({ pageParam = 1 }) => {
-            const baseURL = `${NEXT_PUBLIC_NEST_BFF_URL}/api/gatherings/list`;
-            const query = `page=${pageParam}&size=12`;
-            const keywordQuery = keyword
-                ? `&keyword=${encodeURIComponent(keyword)}`
-                : '';
-            const res = await fetch(`${baseURL}?${query}${keywordQuery}`, {
-                cache: 'no-store',
-            });
-            return res.json();
+            try {
+                return await fetchGatherings(
+                    new URLSearchParams(searchParams.toString()),
+                    pageParam,
+                );
+            } catch (error) {
+                console.error('Fetch error:', error);
+                throw error;
+            }
         },
         getNextPageParam: (lastPage) => {
-            return lastPage.last ? undefined : lastPage.number + 1;
+            if (lastPage.last) return undefined;
+            return lastPage.number + 2;
         },
         initialPageParam: 1,
     });
 
     useEffect(() => {
-        const handleFetchNext = async () => {
+        const timeoutId = setTimeout(() => {
             if (isInView && !isFetchingNextPage && hasNextPage) {
-                await fetchNextPage({ cancelRefetch: false });
+                fetchNextPage({ cancelRefetch: false });
             }
-        };
-
-        // 디바운싱 처리를 통한 데이터 두 번 로드되는 버그 수정
-        const timeoutId = setTimeout(handleFetchNext, 100);
+        }, 300);
         return () => clearTimeout(timeoutId);
     }, [isInView, fetchNextPage, isFetchingNextPage, hasNextPage]);
+
+    useEffect(() => {
+        refetch();
+    }, [searchParams, refetch]);
 
     if (isError) {
         console.error('Error fetching posts data');
         return <CreatePost />;
     }
 
-    const hasNoData = data?.pages[0]?.length === 0;
+    const activeFilters = hasActiveFilters(
+        new URLSearchParams(searchParams.toString()),
+    );
+    const hasNoData = !data?.pages?.[0]?.content?.length;
 
     return (
         <div className="mt-6 grid max-w-[1200px] grid-cols-1 gap-6 lg:grid-cols-2">
-            {/* SSR로 받은 초기 데이터 렌더링 */}
-            {initialPosts.map((post) => (
-                <motion.div
-                    key={`initial-${post.id}`}
-                    initial={{ y: 30, opacity: 0 }}
-                    animate={{ y: 0, opacity: 1 }}
-                    transition={{ duration: 0.3 }}
-                >
-                    <RecruitPost post={post} />
-                </motion.div>
-            ))}
-
-            {/* 클라이언트에서 가져온 나머지 페이지 */}
-            {data?.pages.map((page, pageIndex) =>
-                page.content.map((post: BEHomePost, postIndex: number) => (
+            {!activeFilters &&
+                !data?.pages?.length &&
+                initialPosts?.map((post) => (
                     <motion.div
-                        key={`${pageIndex + 1}-${post.id}`}
+                        key={`initial-${post.id}`}
                         initial={{ y: 30, opacity: 0 }}
                         animate={{ y: 0, opacity: 1 }}
-                        transition={{
-                            duration: 0.3,
-                            delay: postIndex * 0.05,
-                        }}
+                        transition={{ duration: 0.3 }}
                     >
                         <RecruitPost post={post} />
                     </motion.div>
-                )),
+                ))}
+
+            {data?.pages?.map((page, pageIndex) =>
+                (page?.content || []).map(
+                    (post: BEHomePost, postIndex: number) => (
+                        <motion.div
+                            key={`page-${pageIndex}-post-${post.id}`}
+                            initial={{ y: 30, opacity: 0 }}
+                            animate={{ y: 0, opacity: 1 }}
+                            transition={{
+                                duration: 0.3,
+                                delay: postIndex * 0.05,
+                            }}
+                        >
+                            <RecruitPost post={post} />
+                        </motion.div>
+                    ),
+                ),
             )}
 
-            {/* 글이 없는 경우 띄울 Ui */}
             {hasNoData && <CreatePost />}
-
-            {/* 첫 로딩을 끝낸 이후 데이터가 있으면 게시글 작성 버튼을 fixed로 띄웁니다. */}
             {!isLoading && !hasNoData && <CreatePostWindow />}
-
-            <CreatePostWindow />
-
             {isFetchingNextPage && (
                 <div className="col-span-full py-8">
                     <LoadingThreeDots />
                 </div>
             )}
-
             <div className="col-span-full h-1 w-full" ref={ref}></div>
         </div>
     );

--- a/src/components/home/filter/GroupThemeFilter.tsx
+++ b/src/components/home/filter/GroupThemeFilter.tsx
@@ -15,12 +15,12 @@ import { setGroupTheme } from '@/redux/slices/filterSlice';
 import Image from 'next/image';
 
 const groupThemeOptions = [
-    { value: 'friends', label: '친구 동행' },
-    { value: 'couple', label: '부부 동행' },
-    { value: 'tour', label: '투어 동행' },
-    { value: 'booking', label: '숙박 공유' },
-    { value: 'event', label: '전시/공연 동행' },
-    { value: 'food', label: '맛집 동행' },
+    { value: '전시/공연 동행', label: '전시/공연 동행' },
+    { value: '맛집 동행', label: '맛집 동행' },
+    { value: '투어 동행', label: '투어 동행' },
+    { value: '숙박 공유', label: '숙박 공유' },
+    { value: '부분 동행', label: '부분 동행' },
+    { value: '가족 동행', label: '가족 동행' },
 ];
 
 export const GroupThemeFilter = () => {
@@ -41,16 +41,16 @@ export const GroupThemeFilter = () => {
                                 value={option.value}
                                 className="w-fit min-w-[76px]"
                                 variant={
-                                    groupTheme === option.label
+                                    groupTheme === option.value
                                         ? 'selected'
                                         : 'outline'
                                 }
                                 onClick={() =>
                                     dispatch(
                                         setGroupTheme(
-                                            groupTheme === option.label
+                                            groupTheme === option.value
                                                 ? ''
-                                                : option.label,
+                                                : option.value,
                                         ),
                                     )
                                 }


### PR DESCRIPTION
## 작업 내용 요약

1. 위치검색(지도에 등록된 상호명으로 검색해야 함)
2. 선호 성별 및 나이
3. 모집 기간
4. 모임 유형

위 4가지 필터링 기능 구현 (모집 중인 동행만 보기 / n인 동행 두 가지 동작 오류)

- 받은 채팅 메세지 미리보기에서 시간 추가
- 무한스크롤 쪽 버그 수정(같은 게시글이 두 번 받아지는 현상, 같은 컴포넌트를 사용하는 찜한 동행 페이지도 마찬가지)


## 변경사항

- 무한스크롤 쪽에서 검색과 필터링 관련 코드가 함께 작성되면서 컨플릭이 발생했습니다. 
- 우선은 나름대로 합쳐보고 로컬에서 테스트하려는 중에, 서버가 터진듯하여 로컬에서도 테스트가 불가하여 일단 두었고 이 내용 알리기 위해 PR로 남겨둡니다. 기능 작동 확인하기 전까지 merge하지 않겠습니다.
- 서버 이슈로 동작테스트를 못 한 상태라서 이 부분 브랜치 pull 받고 테스트를 해봐야 main 반영 가능해보입니다.


## 기타 참고사항

- 백엔드쪽에서 보내주신 필터링이 된다고하는 부분에서, 마감일이 지난 동행인지는 없는 것 같았고(종료일은 모집 마감일), 체크박스를 눌렀을 때 쿼리파라미터를 전송하는 코드는 짜놨지만 실제로 동작하지 않았습니다.
- 동행 인원인 2인, 10인 이하, ... 를 통해 필터링하는 부분 역시 일단 코드는 짜고 쿼리파라미터로 전달되는 것은 확인했으나 작동하지 않습니다. 이 부분은 아래 이미지에서 '인원 수'로 기입이 되어있어서 백엔드 쪽에서 기능은 만든 것으로 보입니다.
- 현재 기준을 2인, 10인 이상/이하로 해놔서 조금 수정도 필요할 것 같아요. 백엔드쪽 명세서에는 특정 인원 이상으로 필터링하는 것 같은데 10인 미만/10인 이상으로 표기 등을 조정해야할 수 있겠습니다.
- 발표랑 최종 배포가 있어서 일단 제 작업 내용들은 바로 합치지 않고 좀 미룰 수도 있을 것 같습니다.

<img width="210" alt="스크린샷 2025-04-15 오전 12 46 28" src="https://github.com/user-attachments/assets/0639e1b6-1cdf-462d-a2b0-7a7c579a1a11" />

